### PR TITLE
Feature/snap comparison view

### DIFF
--- a/SnapPop.xcodeproj/project.pbxproj
+++ b/SnapPop.xcodeproj/project.pbxproj
@@ -46,12 +46,12 @@
 		C246CE602C74EF8200A631BE /* LegalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C246CE5D2C74EF8200A631BE /* LegalType.swift */; };
 		C246CE612C74EF8200A631BE /* LegalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C246CE5E2C74EF8200A631BE /* LegalViewController.swift */; };
 		C246CE622C74EF8200A631BE /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C246CE5F2C74EF8200A631BE /* SettingViewController.swift */; };
-		C246CE642C74F11300A631BE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C246CE632C74F11300A631BE /* GoogleService-Info.plist */; };
 		C24BFA552C647BA600A5B40A /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = C24BFA542C647BA600A5B40A /* .swiftlint.yml */; };
 		C24BFA632C649CBA00A5B40A /* SignInViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24BFA622C649CBA00A5B40A /* SignInViewController.swift */; };
 		C24BFA672C649CF700A5B40A /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C24BFA662C649CF700A5B40A /* AuthViewModel.swift */; };
 		C24BFA6A2C649E4300A5B40A /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = C24BFA692C649E4300A5B40A /* GoogleSignIn */; };
 		C24BFA6C2C649E4300A5B40A /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C24BFA6B2C649E4300A5B40A /* GoogleSignInSwift */; };
+		C24E0AFC2C762ECF00CCC055 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C24E0AFB2C762ECF00CCC055 /* GoogleService-Info.plist */; };
 		C2599B382C699B05004EF6E7 /* LocalAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2599B372C699B05004EF6E7 /* LocalAuthenticationViewModel.swift */; };
 		C2734C3B2C69F1D200E45294 /* CategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2734C3A2C69F1D200E45294 /* CategoryService.swift */; };
 		C2D4015B2C73788D000E0343 /* DetailCostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */; };
@@ -108,11 +108,12 @@
 		C246CE5D2C74EF8200A631BE /* LegalType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegalType.swift; sourceTree = "<group>"; };
 		C246CE5E2C74EF8200A631BE /* LegalViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LegalViewController.swift; sourceTree = "<group>"; };
 		C246CE5F2C74EF8200A631BE /* SettingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
-		C246CE632C74F11300A631BE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../Downloads/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C24BFA542C647BA600A5B40A /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		C24BFA622C649CBA00A5B40A /* SignInViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInViewController.swift; sourceTree = "<group>"; };
 		C24BFA662C649CF700A5B40A /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		C24BFA722C64B01400A5B40A /* SnapPop.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SnapPop.entitlements; sourceTree = "<group>"; };
+		C24E0AFA2C762EB800CCC055 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		C24E0AFB2C762ECF00CCC055 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C2599B372C699B05004EF6E7 /* LocalAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthenticationViewModel.swift; sourceTree = "<group>"; };
 		C2734C3A2C69F1D200E45294 /* CategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryService.swift; sourceTree = "<group>"; };
 		C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCostViewController.swift; sourceTree = "<group>"; };
@@ -216,6 +217,7 @@
 		8F1685232C6354590010F8D8 = {
 			isa = PBXGroup;
 			children = (
+				C24E0AFA2C762EB800CCC055 /* Config.xcconfig */,
 				C24BFA542C647BA600A5B40A /* .swiftlint.yml */,
 				8F16852E2C6354590010F8D8 /* SnapPop */,
 				8F16852D2C6354590010F8D8 /* Products */,
@@ -242,7 +244,7 @@
 				C24BFA5B2C64801100A5B40A /* ViewModels */,
 				C24BFA582C647E9800A5B40A /* Resources */,
 				8F16853D2C63545A0010F8D8 /* Info.plist */,
-				C246CE632C74F11300A631BE /* GoogleService-Info.plist */,
+				C24E0AFB2C762ECF00CCC055 /* GoogleService-Info.plist */,
 			);
 			path = SnapPop;
 			sourceTree = "<group>";
@@ -510,7 +512,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C24BFA552C647BA600A5B40A /* .swiftlint.yml in Resources */,
-				C246CE642C74F11300A631BE /* GoogleService-Info.plist in Resources */,
+				C24E0AFC2C762ECF00CCC055 /* GoogleService-Info.plist in Resources */,
 				8F1685392C63545A0010F8D8 /* Assets.xcassets in Resources */,
 				8F16853C2C63545A0010F8D8 /* Base in Resources */,
 			);
@@ -614,6 +616,7 @@
 /* Begin XCBuildConfiguration section */
 		8F16853E2C63545A0010F8D8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C24E0AFA2C762EB800CCC055 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -677,6 +680,7 @@
 		};
 		8F16853F2C63545A0010F8D8 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = C24E0AFA2C762EB800CCC055 /* Config.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/SnapPop.xcodeproj/project.pbxproj
+++ b/SnapPop.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		C24BFA6C2C649E4300A5B40A /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = C24BFA6B2C649E4300A5B40A /* GoogleSignInSwift */; };
 		C24E0AFC2C762ECF00CCC055 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C24E0AFB2C762ECF00CCC055 /* GoogleService-Info.plist */; };
 		C2599B382C699B05004EF6E7 /* LocalAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2599B372C699B05004EF6E7 /* LocalAuthenticationViewModel.swift */; };
+		C259C8142C784610004F569A /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C259C8132C784610004F569A /* UIImageView+Extensions.swift */; };
 		C2734C3B2C69F1D200E45294 /* CategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2734C3A2C69F1D200E45294 /* CategoryService.swift */; };
 		C2D4015B2C73788D000E0343 /* DetailCostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */; };
 		C2D401602C73853B000E0343 /* CustomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D4015F2C73853B000E0343 /* CustomTableViewCell.swift */; };
@@ -115,6 +116,7 @@
 		C24E0AFA2C762EB800CCC055 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		C24E0AFB2C762ECF00CCC055 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		C2599B372C699B05004EF6E7 /* LocalAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAuthenticationViewModel.swift; sourceTree = "<group>"; };
+		C259C8132C784610004F569A /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		C2734C3A2C69F1D200E45294 /* CategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryService.swift; sourceTree = "<group>"; };
 		C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCostViewController.swift; sourceTree = "<group>"; };
 		C2D4015F2C73853B000E0343 /* CustomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTableViewCell.swift; sourceTree = "<group>"; };
@@ -359,6 +361,7 @@
 			children = (
 				4AD29AD42C6AE1F200A9BEDD /* UIView+Extensions.swift */,
 				4AD29AD72C6B35BE00A9BEDD /* Color+Extensions.swift */,
+				C259C8132C784610004F569A /* UIImageView+Extensions.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -572,6 +575,7 @@
 				8F1685302C6354590010F8D8 /* AppDelegate.swift in Sources */,
 				8F1685532C6599A20010F8D8 /* CalendarViewController.swift in Sources */,
 				C2D401602C73853B000E0343 /* CustomTableViewCell.swift in Sources */,
+				C259C8142C784610004F569A /* UIImageView+Extensions.swift in Sources */,
 				EA141FA02C6AFC8400DD4B29 /* ChecklistTableViewController.swift in Sources */,
 				C2599B382C699B05004EF6E7 /* LocalAuthenticationViewModel.swift in Sources */,
 				8F4C73C22C6B1E71000AACDA /* svenmodels.swift in Sources */,

--- a/SnapPop.xcodeproj/project.pbxproj
+++ b/SnapPop.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		4A20F6472C6C32B600F263FF /* SnapComparisonSheetViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20F6462C6C32B600F263FF /* SnapComparisonSheetViewModel.swift */; };
 		4A20F6492C6C32E900F263FF /* SnapComparisonCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20F6482C6C32E900F263FF /* SnapComparisonCellViewModel.swift */; };
 		4A82A7E92C7392D500E27228 /* CategorySettingsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82A7E82C7392D500E27228 /* CategorySettingsTableViewCell.swift */; };
+		4AC605B42C78769D00D3AF19 /* Kingfisher in Frameworks */ = {isa = PBXBuildFile; productRef = 4AC605B32C78769D00D3AF19 /* Kingfisher */; };
 		4AC9A0302C72DDD100EB5FFC /* CustomNavigationBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9A02F2C72DDD100EB5FFC /* CustomNavigationBarController.swift */; };
 		4AC9A0322C72DE0C00EB5FFC /* CustomTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9A0312C72DE0C00EB5FFC /* CustomTabBarController.swift */; };
 		4AC9A0392C72E96700EB5FFC /* NotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC9A0382C72E96700EB5FFC /* NotificationViewController.swift */; };
@@ -135,6 +136,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AC605B42C78769D00D3AF19 /* Kingfisher in Frameworks */,
 				C24BFA6C2C649E4300A5B40A /* GoogleSignInSwift in Frameworks */,
 				8F1685492C6360180010F8D8 /* FirebaseAuth in Frameworks */,
 				C24BFA6A2C649E4300A5B40A /* GoogleSignIn in Frameworks */,
@@ -289,14 +291,6 @@
 				C246CE582C74EF7D00A631BE /* SettingTableViewCell.swift */,
 			);
 			path = Cells;
-			sourceTree = "<group>";
-		};
-		C2008C282C7461EB005FC906 /* DetailCost */ = {
-			isa = PBXGroup;
-			children = (
-				C2008C292C7461FE005FC906 /* DetailCostViewModel.swift */,
-			);
-			path = DetailCost;
 			sourceTree = "<group>";
 		};
 		C24BFA572C647E7800A5B40A /* Application */ = {
@@ -465,6 +459,7 @@
 				8F16854C2C6360180010F8D8 /* FirebaseStorage */,
 				C24BFA692C649E4300A5B40A /* GoogleSignIn */,
 				C24BFA6B2C649E4300A5B40A /* GoogleSignInSwift */,
+				4AC605B32C78769D00D3AF19 /* Kingfisher */,
 			);
 			productName = SnapPop;
 			productReference = 8F16852C2C6354590010F8D8 /* SnapPop.app */;
@@ -498,6 +493,7 @@
 				8F1685472C6360180010F8D8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				C24BFA522C647B6900A5B40A /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
 				C24BFA682C649E4300A5B40A /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+				4AC605B22C78769D00D3AF19 /* XCRemoteSwiftPackageReference "Kingfisher" */,
 			);
 			productRefGroup = 8F16852D2C6354590010F8D8 /* Products */;
 			projectDirPath = "";
@@ -556,13 +552,10 @@
 				C2734C3B2C69F1D200E45294 /* CategoryService.swift in Sources */,
 				4AC9A0302C72DDD100EB5FFC /* CustomNavigationBarController.swift in Sources */,
 				C246CE602C74EF8200A631BE /* LegalType.swift in Sources */,
-				4AC9A0362C72E23900EB5FFC /* TestCalendarViewController.swift in Sources */,
-				8F1685342C6354590010F8D8 /* ViewController.swift in Sources */,
 				C2F8B19F2C6A4FD900D73071 /* ManagementService.swift in Sources */,
 				B8339E052C76C7350021A57D /* CustomAddTableViewCell.swift in Sources */,
 				4AD29AA82C6512E800A9BEDD /* HorizontalSnapPhotoCollectionViewCell.swift in Sources */,
 				4AC9A0392C72E96700EB5FFC /* NotificationViewController.swift in Sources */,
-				8F1685342C6354590010F8D8 /* ViewController.swift in Sources */,
 				C246CE5B2C74EF7D00A631BE /* AppLockSettingTableViewCell.swift in Sources */,
 				B8339E042C76C7350021A57D /* AddManagementViewController.swift in Sources */,
 				EA57EB482C72CAAC007F8987 /* Category.swift in Sources */,
@@ -824,6 +817,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4AC605B22C78769D00D3AF19 /* XCRemoteSwiftPackageReference "Kingfisher" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/onevcat/Kingfisher.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 7.12.0;
+			};
+		};
 		8F1685472C6360180010F8D8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
@@ -851,6 +852,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4AC605B32C78769D00D3AF19 /* Kingfisher */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4AC605B22C78769D00D3AF19 /* XCRemoteSwiftPackageReference "Kingfisher" */;
+			productName = Kingfisher;
+		};
 		8F1685482C6360180010F8D8 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8F1685472C6360180010F8D8 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/SnapPop/Common/UIImageView+Extensions.swift
+++ b/SnapPop/Common/UIImageView+Extensions.swift
@@ -1,0 +1,22 @@
+//
+//  UIImageView+Extensions.swift
+//  SnapPop
+//
+//  Created by 이인호 on 8/23/24.
+//
+
+import UIKit
+
+extension UIImageView {
+    func load(url: URL) {
+        DispatchQueue.global().async { [weak self] in
+            if let data = try? Data(contentsOf: url) {
+                if let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.image = image
+                    }
+                }
+            }
+        }
+    }
+}

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -80,8 +80,11 @@ final class SnapService {
                     completion(.failure(error))
                     return
                 }
-                guard let document = querySnapshot?.documents.first else { return }
-                
+                guard let document = querySnapshot?.documents.first else {
+                    completion(.failure(NSError(domain: "NoDocumentError", code: -1, userInfo: nil)))
+                    return
+                }
+                    
                 do {
                     let snap = try document.data(as: Snap.self)
                     completion(.success(snap))
@@ -143,7 +146,7 @@ final class SnapService {
             }
     }
     
-    func updateSnap(categoryId: String, snap: Snap, newImageUrls: [String], completion: @escaping (Result<Void, Error>) -> Void) {
+    func updateSnap(categoryId: String, snap: Snap, newImageUrls: [String], completion: @escaping (Result<Snap, Error>) -> Void) {
         if let snapId = snap.id {
             var imageUrls = snap.imageUrls
             imageUrls.append(contentsOf: newImageUrls)
@@ -159,7 +162,7 @@ final class SnapService {
                         completion(.failure(error))
                         return
                     }
-                    completion(.success(()))
+                    completion(.success(snap))
                 }
         }
     }
@@ -190,6 +193,22 @@ final class SnapService {
                             return
                         }
                         completion(.success(()))
+                    }
+                }
+        }
+    }
+    
+    func deleteSnap(categoryId: String, snap: Snap, completion: @escaping (Error?) -> Void) {
+        if let snapId = snap.id {
+            db.collection("Users")
+                .document(AuthViewModel.shared.currentUser?.uid ?? "")
+                .collection("Categories")
+                .document(categoryId)
+                .collection("Snaps")
+                .document(snapId)
+                .delete { error in
+                    if let error = error {
+                        completion(error)
                     }
                 }
         }

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -35,16 +35,21 @@ final class SnapService {
             }
         }
     }
-    
+      
     func saveSnap(categoryId: String, imageUrls: [String], completion: @escaping (Result<Void, Error>) -> Void) {
-        let snap = Snap(id: nil, imageUrls: imageUrls, createdAt: nil)
+        // 생성할 문서의 ID를 직접 지정
+        let documentID = UUID().uuidString // 또는 원하는 다른 ID를 지정할 수 있습니다.
+        
+        let snap = Snap(id: documentID, imageUrls: imageUrls, createdAt: nil)
+        
         do {
             try db.collection("Users")
                 .document(AuthViewModel.shared.currentUser?.uid ?? "")
                 .collection("Categories")
                 .document(categoryId)
                 .collection("Snaps")
-                .addDocument(from: snap) { error in
+                .document(documentID) // 지정한 documentID로 문서를 생성
+                .setData(from: snap) { error in
                     if let error = error {
                         completion(.failure(error))
                         return
@@ -127,6 +132,7 @@ final class SnapService {
             .collection("Snaps")
             .getDocuments { (querySnapshot, error) in
                 if let error = error {
+                    print("Error fetching documents: \(error.localizedDescription)")
                     completion(.failure(error))
                     return
                 }

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -130,6 +130,7 @@ final class SnapService {
             .collection("Categories")
             .document(categoryId)
             .collection("Snaps")
+            .order(by: "createdAt", descending: false)
             .getDocuments { (querySnapshot, error) in
                 if let error = error {
                     print("Error fetching documents: \(error.localizedDescription)")

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -148,8 +148,10 @@ final class SnapService {
     
     func updateSnap(categoryId: String, snap: Snap, newImageUrls: [String], completion: @escaping (Result<Snap, Error>) -> Void) {
         if let snapId = snap.id {
-            var imageUrls = snap.imageUrls
-            imageUrls.append(contentsOf: newImageUrls)
+            var updatedSnap = snap
+            updatedSnap.imageUrls.append(contentsOf: newImageUrls)
+//            var imageUrls = snap.imageUrls
+//            imageUrls.append(contentsOf: newImageUrls)
             
             db.collection("Users")
                 .document(AuthViewModel.shared.currentUser?.uid ?? "")
@@ -157,12 +159,12 @@ final class SnapService {
                 .document(categoryId)
                 .collection("Snaps")
                 .document(snapId)
-                .updateData(["imageUrls": imageUrls]) { error in
+                .updateData(["imageUrls": updatedSnap.imageUrls]) { error in
                     if let error = error {
                         completion(.failure(error))
                         return
                     }
-                    completion(.success(snap))
+                    completion(.success(updatedSnap))
                 }
         }
     }

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -31,16 +31,14 @@ final class SnapService {
                 
                 guard let downloadUrl = url?.absoluteString else { return }
                 
+                print(downloadUrl)
                 completion(.success(downloadUrl))
             }
         }
     }
       
-    func saveSnap(categoryId: String, imageUrls: [String], completion: @escaping (Result<Void, Error>) -> Void) {
-        // 생성할 문서의 ID를 직접 지정
-        let documentID = UUID().uuidString // 또는 원하는 다른 ID를 지정할 수 있습니다.
-        
-        let snap = Snap(id: documentID, imageUrls: imageUrls, createdAt: nil)
+    func saveSnap(categoryId: String, imageUrls: [String], completion: @escaping (Result<Snap, Error>) -> Void) {
+        let snap = Snap(imageUrls: imageUrls, createdAt: Date())
         
         do {
             try db.collection("Users")
@@ -48,13 +46,12 @@ final class SnapService {
                 .collection("Categories")
                 .document(categoryId)
                 .collection("Snaps")
-                .document(documentID) // 지정한 documentID로 문서를 생성
-                .setData(from: snap) { error in
+                .addDocument(from: snap) { error in
                     if let error = error {
                         completion(.failure(error))
                         return
                     }
-                    completion(.success(()))
+                    completion(.success((snap)))
                 }
         } catch {
             completion(.failure(error))

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -37,8 +37,8 @@ final class SnapService {
         }
     }
       
-    func saveSnap(categoryId: String, imageUrls: [String], completion: @escaping (Result<Snap, Error>) -> Void) {
-        let snap = Snap(imageUrls: imageUrls, createdAt: Date())
+    func saveSnap(categoryId: String, imageUrls: [String], createdAt: Date, completion: @escaping (Result<Snap, Error>) -> Void) {
+        let snap = Snap(imageUrls: imageUrls, createdAt: createdAt)
         
         do {
             try db.collection("Users")

--- a/SnapPop/Models/Snap.swift
+++ b/SnapPop/Models/Snap.swift
@@ -10,7 +10,7 @@ import FirebaseStorage
 
 struct Snap: Identifiable, Hashable, Codable {
     @DocumentID var id: String?
-    let imageUrls: [String]
+    var imageUrls: [String]
     @ServerTimestamp var createdAt: Date?
     
     init(imageUrls: [String], createdAt: Date) {

--- a/SnapPop/Models/Snap.swift
+++ b/SnapPop/Models/Snap.swift
@@ -13,8 +13,7 @@ struct Snap: Identifiable, Hashable, Codable {
     let imageUrls: [String]
     @ServerTimestamp var createdAt: Date?
     
-    init(id: String?, imageUrls: [String], createdAt: Date?) {
-        self.id = id
+    init(imageUrls: [String], createdAt: Date) {
         self.imageUrls = imageUrls
         self.createdAt = createdAt
     }

--- a/SnapPop/ViewModels/Home/HomeViewModel.swift
+++ b/SnapPop/ViewModels/Home/HomeViewModel.swift
@@ -15,7 +15,6 @@ class HomeViewModel: ObservableObject {
     
     private let snapService = SnapService()
     private let managementService = ManagementService() // ManagementService 인스턴스
-    
     // MARK: - Properties
     @Published var checklistItems: [Management] = []
     @Published var snapData: [Snap] = []
@@ -24,9 +23,8 @@ class HomeViewModel: ObservableObject {
 
     // MARK: - Initialization
     init() {
-        loadChecklistItems() // 초기 로드
+        //loadChecklistItems() // 초기 로드
     }
-    
     /// Image Picker Methods
     func dateChanged(_ sender: UIDatePicker) -> String {
         let dateFormatter = DateFormatter()
@@ -51,7 +49,8 @@ class HomeViewModel: ObservableObject {
             }
         }
     }
-    /// 스냅 사진 드랍 후 배열 재정의
+    
+    // 스냅 사진 드랍 후 배열 재정의
 //    func droptoSnapUpdate(from sourceIndex: Int, to destinationIndex: Int) {
 //        guard sourceIndex != destinationIndex, sourceIndex < snapData.count else { return }
 //        
@@ -106,39 +105,64 @@ class HomeViewModel: ObservableObject {
     }
     
     // 스냅 리스트 로드 기능
-    func loadSnaps(categoryId: String) {
-        snapService.loadSnaps(categoryId: categoryId) { [weak self] result in
-            switch result {
-            case .success(let snaps):
-                DispatchQueue.main.async {
-                    self?.snapData = snaps // Combine을 통해 UI에 자동으로 반영
-                    print("Snaps loaded successfully.")
-                }
-            case .failure(let error):
-                print("Error loading snaps: \(error.localizedDescription)")
-            }
-        }
-    }
+//    func loadSnaps() {
+////        guard let categoryId = navigationViewModel.currentCategory?.id else {
+////            print("Category ID is missing.")
+////            return
+////        }
+//
+//        snapService.loadSnaps(categoryId: "kzbh5r58xqs95cl2sXEK") { [weak self] result in
+//            switch result {
+//            case .success(let snaps):
+//                DispatchQueue.main.async {
+//                    // PHAsset 관련 기능 제거
+//                    self?.snapData = snaps // Snap 객체를 그대로 사용
+//                    print("Snaps loaded successfully.")
+//                }
+//            case .failure(let error):
+//                print("Error loading snaps: \(error.localizedDescription)")
+//            }
+//        }
+//    }
+    
+    func loadSnaps() {
+        let categoryId = "kzbh5r58xqs95cl2sXEK"
+        let snapDate = Date() // 여기서는 현재 날짜를 사용, 필요에 따라 변경 가능
 
-    // 체크리스트 아이템 로드
-    func loadChecklistItems() {
-        guard let categoryId = selectedCategoryId else {
-            print("Category ID is missing.")
-            return
-        }
-        
-        managementService.loadManagements(categoryId: categoryId) { [weak self] result in
+        snapService.loadSnap(categoryId: categoryId, snapDate: snapDate) { [weak self] result in
             switch result {
-            case .success(let items):
+            case .success(let snap):
                 DispatchQueue.main.async {
-                    self?.checklistItems = items // Combine을 통해 UI에 자동으로 반영
-                    print("Checklist items loaded successfully.")
+                    // 단일 Snap 객체를 snapData 배열에 추가 (또는 배열 전체를 교체)
+                    self?.snapData = [snap] // Snap 객체를 배열로 만들어 사용
+                    print("Snap loaded successfully.")
                 }
             case .failure(let error):
-                print("Error loading checklist items: \(error.localizedDescription)")
+                print("Error loading snap: \(error.localizedDescription)")
             }
         }
     }
+    
+
+//    // 체크리스트 아이템 로드
+//    func loadChecklistItems() {
+//        guard let categoryId = navigationViewModel.currentCategoryId else {
+//            print("Category ID is missing.")
+//            return
+//        }
+//        
+//        managementService.loadManagements(categoryId: categoryId) { [weak self] result in
+//            switch result {
+//            case .success(let items):
+//                DispatchQueue.main.async {
+//                    self?.checklistItems = items // Combine을 통해 UI에 자동으로 반영
+//                    print("Checklist items loaded successfully.")
+//                }
+//            case .failure(let error):
+//                print("Error loading checklist items: \(error.localizedDescription)")
+//            }
+//        }
+//    }
 
         
     /// 액션시트에 선택된 옵션에 따른 처리 메소드
@@ -289,4 +313,11 @@ class HomeViewModel: ObservableObject {
 //            }
 //        }
 //    }
+}
+
+// PHAsset을 가져오는 메서드
+private func fetchPHAsset(for snap: Snap) -> PHAsset? {
+    // PHAsset을 가져오는 로직을 구현합니다.
+    // 예를 들어, imageUrls를 사용하여 PHAsset을 찾는 방법을 구현할 수 있습니다.
+    return nil // 실제 구현 필요
 }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonCellViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonCellViewModel.swift
@@ -9,19 +9,19 @@ import Foundation
 import UIKit
 
 protocol SnapComparisonCellViewModelProtocol {
-    var snapPhotos: [UIImage] { get set }
+    var snapPhotos: [String] { get set }
     var currentSectionIndex: Int { get set }
-    var filteredSnapData: [MockSnap] { get set }
+    var filteredSnapData: [Snap] { get set }
     var numberOfSections: Int { get }
     func numberOfRows(in section: Int) -> Int
 }
 
 class SnapComparisonCellViewModel: SnapComparisonCellViewModelProtocol {
     // MARK: - Properties
-    var snapPhotos: [UIImage] = []
+    var snapPhotos: [String] = []
     /// 현재 섹션의 인덱스 저장 변수
     var currentSectionIndex: Int = 0
-    var filteredSnapData: [MockSnap] = []
+    var filteredSnapData: [Snap] = []
     var numberOfSections: Int {
         snapPhotos.count
     }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
@@ -25,6 +25,7 @@ protocol SnapComparisonSheetViewModelProtocol {
     func getSnapPhoto(at index: Int, completion: @escaping (UIImage?) -> Void)
     func moveToPreviousSnap()
     func moveToNextSnap()
+    func getDateString() -> String
 }
 
 class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
@@ -67,10 +68,6 @@ class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
             return
         }
         
-//        if let url = URL(string: currentSnap.imageUrls[index]) {
-//            let image = UIImage.loadImage(from: url)
-//            return image
-//        }
         if let url = URL(string: currentSnap.imageUrls[index]) {
             KingfisherManager.shared.retrieveImage(with: url) { result in
                 switch result {
@@ -97,5 +94,20 @@ class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
         currentDateIndex += 1
         currentPhotoIndex = 0
         updateSnapData()
+    }
+    /// 날자 형식 변환 메소드
+    func updateDate(to date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 d일"
+        let updatedDateString = formatter.string(from: date)
+        return updatedDateString
+    }
+    
+    func getDateString() -> String {
+        guard let date = currentSnap.createdAt else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 d일"
+        let updatedDateString = formatter.string(from: date)
+        return updatedDateString
     }
 }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
@@ -9,11 +9,11 @@ import Foundation
 import UIKit
 
 protocol SnapComparisonSheetViewModelProtocol {
-    var filteredSnapData: [MockSnap] { get set}
+    var filteredSnapData: [Snap] { get set}
     var selectedIndex: Int { get set}
     var currentDateIndex: Int { get set}
     var currentPhotoIndex: Int { get set}
-    var currentSnap: MockSnap { get }
+    var currentSnap: Snap { get }
     var isLeftArrowHidden: Bool { get }
     var isRightArrowHidden: Bool { get }
     
@@ -28,12 +28,12 @@ protocol SnapComparisonSheetViewModelProtocol {
 
 class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
     // MARK: - Properties
-    var filteredSnapData: [MockSnap] = []
+    var filteredSnapData: [Snap] = []
     var selectedIndex: Int = 0
     var currentDateIndex: Int = 0
     /// 페이지뷰 컨트롤러 인덱스
     var currentPhotoIndex: Int = 0
-    var currentSnap: MockSnap {
+    var currentSnap: Snap {
         guard currentDateIndex >= 0, currentDateIndex < filteredSnapData.count else {
             print("currentDateIndex: \(currentDateIndex), filteredSnapData.count: \(filteredSnapData.count)")
             fatalError("currentDateIndex가 잘못된 범위를 참조하고 있습니다.")
@@ -56,15 +56,21 @@ class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
     
     func updateSnapData() {
         updateUI?()
-        updatePageControl?(currentPhotoIndex, currentSnap.images.count)
+        updatePageControl?(currentPhotoIndex, currentSnap.imageUrls.count)
         updateArrowVisibility?(isLeftArrowHidden, isRightArrowHidden)
     }
     
     func getSnapPhoto(at index: Int) -> UIImage? {
-        guard index >= 0, index < currentSnap.images.count  else {
+        guard index >= 0, index < currentSnap.imageUrls.count  else {
             return nil
         }
-        return currentSnap.images[index]
+        
+        if let url = URL(string: currentSnap.imageUrls[index]) {
+            let image = UIImage.loadImage(from: url)
+            return image
+        }
+        
+        return UIImage(systemName: "person.fill")
     }
     
     func moveToPreviousSnap() {

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonSheetViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import UIKit
+import Kingfisher
 
 protocol SnapComparisonSheetViewModelProtocol {
     var filteredSnapData: [Snap] { get set}
@@ -21,7 +22,7 @@ protocol SnapComparisonSheetViewModelProtocol {
     var updatePageControl: ((Int, Int) -> Void)? { get set }
     var updateArrowVisibility: ((Bool, Bool) -> Void)? { get set }
     func updateSnapData()
-    func getSnapPhoto(at index: Int) -> UIImage?
+    func getSnapPhoto(at index: Int, completion: @escaping (UIImage?) -> Void)
     func moveToPreviousSnap()
     func moveToNextSnap()
 }
@@ -60,17 +61,28 @@ class SnapComparisonSheetViewModel: SnapComparisonSheetViewModelProtocol {
         updateArrowVisibility?(isLeftArrowHidden, isRightArrowHidden)
     }
     
-    func getSnapPhoto(at index: Int) -> UIImage? {
+    func getSnapPhoto(at index: Int, completion: @escaping (UIImage?) -> Void) {
         guard index >= 0, index < currentSnap.imageUrls.count  else {
-            return nil
+            completion(UIImage(systemName: "circle.dotted"))
+            return
         }
         
+//        if let url = URL(string: currentSnap.imageUrls[index]) {
+//            let image = UIImage.loadImage(from: url)
+//            return image
+//        }
         if let url = URL(string: currentSnap.imageUrls[index]) {
-            let image = UIImage.loadImage(from: url)
-            return image
+            KingfisherManager.shared.retrieveImage(with: url) { result in
+                switch result {
+                case .success(let value):
+                    completion(value.image)
+                case .failure:
+                    completion(UIImage(systemName: "circle.dotted"))
+                }
+            }
+        } else {
+            completion(UIImage(systemName: "circle.dotted"))
         }
-        
-        return UIImage(systemName: "person.fill")
     }
     
     func moveToPreviousSnap() {

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -138,7 +138,6 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
     // MARK: - Methods
     /// 스냅 데이터 필터링 메소드
     func filterSnaps() {
-//        filteredSnapData = mockData
          filteredSnapData = snapData
         
         if snapPeriodType != "전체" {
@@ -147,9 +146,9 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
         
         if snapPhotoSelectionType == "메인 사진" {
             filteredSnapData = filteredSnapData.map({ snap in
-//                Snap(date: snap.date, images: Array(snap.images.prefix(1)))
                 let mainImage = snap.imageUrls.first.map { [$0] } ?? []
-                return Snap(id: snap.id, imageUrls: mainImage, createdAt: snap.createdAt)
+                guard let createdAt = snap.createdAt else { return Snap(imageUrls: [], createdAt: Date()) }
+                return Snap(imageUrls: mainImage, createdAt: createdAt)
             })
         }
         print("필터링된 스냅 개수: \(filteredSnapData.count)")
@@ -200,6 +199,7 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
                 } else {
                     print("[Snap비교] 카테고리, 스냅 존재")
                     self.snapData = snaps
+                    self.filterSnaps()
                     self.showSnapCollectionView?()
                 }
             case.failure(let error):

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -163,7 +163,6 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
         }
     }
     
-    // https://minzombie.github.io/ios/calendar/
     func filterSnapsByPeriod(_ snaps: [Snap], periodType: String) -> [Snap] {
         // 첫번째 스냅 데이터가 기준
         guard let firstSnapDate = snaps.first?.createdAt else { return snaps }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -161,6 +161,9 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
         } else {
             showSnapCollectionView?()
         }
+        
+        // 최신 순으로 보여주기
+        filteredSnapData = filteredSnapData.reversed()
     }
     
     func filterSnapsByPeriod(_ snaps: [Snap], periodType: String) -> [Snap] {
@@ -177,7 +180,7 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
             switch periodType {
             case "일주일":
                 // 첫 번째 스냅과 일주일 간격이라면
-                shouldInclude = Calendar.current.dateComponents([.day], from: standardDate, to: date).day ?? 1 >= 7
+                shouldInclude = Calendar.current.dateComponents([.day], from: standardDate, to: date).day ?? 0 >= 7
             case "한달":
                 // 첫 번째 스냅과 한달 간격이라면
                 shouldInclude = Calendar.current.dateComponents([.month], from: standardDate, to: date).month ?? 0 >= 1

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -226,6 +226,7 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
     func categoryDidChange(to newCategoryId: String) {
         print("[Snap비교] 스냅 비교뷰 카테고리 변경됨 \(newCategoryId)")
         loadSanpstoFireStore(to: newCategoryId)
+        reloadCollectionView?()
     }
     
     /// Firebase Snap Load Method

--- a/SnapPop/Views/Home/CropViewController.swift
+++ b/SnapPop/Views/Home/CropViewController.swift
@@ -261,14 +261,14 @@ class CropViewController: UIViewController {
         }
         
         // HomeViewModel에 이미지 저장 요청
-        viewModel.saveCroppedSnapData(image: croppedImage, assetIdentifier: asset.localIdentifier, categoryId: categoryId) { [weak self] (result: Result<Void, Error>) in
-            switch result {
-            case .success:
-                print("Cropped image saved successfully.")
-            case .failure(let error):
-                print("Failed to save cropped image: \(error.localizedDescription)")
-            }
-        }
+//        viewModel.saveCroppedSnapData(image: croppedImage, assetIdentifier: asset.localIdentifier, categoryId: categoryId) { [weak self] (result: Result<Void, Error>) in
+//            switch result {
+//            case .success:
+//                print("Cropped image saved successfully.")
+//            case .failure(let error):
+//                print("Failed to save cropped image: \(error.localizedDescription)")
+//            }
+//        }
         
         let croppedImageView = UIImageView(image: croppedImage)
         croppedImageView.frame = self.view.bounds

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -41,6 +41,11 @@ class HomeViewController:
     private var viewModel = HomeViewModel(snapService: SnapService())
     var navigationBarViewModel: CustomNavigationBarViewModelProtocol // 프로퍼티로 선언
     
+    private var selections = [String : PHPickerResult]()
+    // 선택한 사진의 순서에 맞게 Identifier들을 배열로 저장해줄 겁니다.
+    // selections은 딕셔너리이기 때문에 순서가 없습니다. 그래서 따로 식별자를 담을 배열 생성
+    private var selectedAssetIdentifiers = [String]()
+    
     // 초기화 메서드 추가
     init(navigationBarViewModel: CustomNavigationBarViewModelProtocol) {
         self.navigationBarViewModel = navigationBarViewModel
@@ -136,9 +141,9 @@ class HomeViewController:
         }
         
         // 스냅 데이터가 변경될 때 UI 업데이트
-        viewModel.$snapData.sink { [weak self] _ in
-            self?.snapCollectionView.reloadData() // UI 업데이트
-        }.store(in: &cancellables)
+//        viewModel.$snap.sink { [weak self] _ in
+//            self?.snapCollectionView.reloadData() // UI 업데이트
+//        }.store(in: &cancellables)
         
         // 카테고리 로드
         navigationBarViewModel.loadCategories { [weak self] in
@@ -146,7 +151,15 @@ class HomeViewController:
             self?.updateUIWithCategories()
         }
         
-        viewModel.loadSnap(categoryId: "nhY7XXG7lm7gy7eUgLxi", snapDate: Date())
+        guard let categoryId = UserDefaults.standard.string(forKey: "currentCategoryId") else {
+            return // categoryId가 nil인 경우, cropImage 메서드를 종료
+        }
+        
+        viewModel.loadSnap(categoryId: categoryId, snapDate: datePicker.date) { [weak self] in
+            DispatchQueue.main.async {
+                self?.snapCollectionView.reloadData()
+            }
+        }
     }
     
     @objc private func updateSnapCollectionView() {
@@ -210,7 +223,15 @@ class HomeViewController:
     
     // MARK: - 날짜 변경 시 호출
     @objc private func dateChanged(_ sender: UIDatePicker) {
-        viewModel.dateChanged(sender)
+        guard let categoryId = UserDefaults.standard.string(forKey: "currentCategoryId") else {
+            return // categoryId가 nil인 경우, cropImage 메서드를 종료
+        }
+        
+        viewModel.loadSnap(categoryId: categoryId, snapDate: sender.date) { [weak self] in
+            DispatchQueue.main.async {
+                self?.snapCollectionView.reloadData()
+            }
+        }
     }
     
     // MARK: - 체크리스트 관련 요소 제약조건
@@ -290,7 +311,7 @@ class HomeViewController:
     
     // MARK: UICollectionViewDataSource
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return viewModel.snap.imageUrls.count
+        return viewModel.snap?.imageUrls.count ?? 0
     }
     
     // MARK: UICollectionViewDataSource - Cell Configuration
@@ -298,19 +319,14 @@ class HomeViewController:
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "SnapCollectionViewCell", for: indexPath) as! SnapCollectionViewCell
         
         let isFirst = indexPath.item == 0
+        guard let snap = viewModel.snap else {
+            return cell
+        }
         
-        cell.configure(with: viewModel.snap, index: indexPath.item, isFirst: isFirst, isEditing: self.isEditingMode)
+        cell.configure(with: snap, index: indexPath.item, isFirst: isFirst, isEditing: self.isEditingMode)
         cell.deleteButton.tag = indexPath.item
         cell.deleteButton.addTarget(self, action: #selector(self.deleteButtonTapped(_:)), for: .touchUpInside)
         return cell
-//        let snap =
-//        let isFirst = indexPath.item == 0
-//        
-//        cell.configure(with: snap, isFirst: isFirst, isEditing: isEditingMode)
-//        cell.deleteButton.tag = indexPath.item
-//        cell.deleteButton.addTarget(self, action: #selector(deleteButtonTapped(_:)), for: .touchUpInside)
-//        
-//        return cell
     }
     
     // MARK: UICollectionViewDelegateFlowLayout
@@ -327,16 +343,24 @@ class HomeViewController:
             // 편집 모드로 전환
             editButton.setTitle("완료", for: .normal)
         } else {
-            // 편집 모드 종료, 데이터 저장
-            //viewModel.saveSnapsToFirebase()
+            // 편집 모드 종료
             editButton.setTitle("편집", for: .normal)
         }
         
-        snapCollectionView.reloadData() // 데이터 변경 반영
+        updateVisibleCellsForEditingMode(isEditingMode) // 모드 전환 시 셀 업데이트
+    }
+    
+    private func updateVisibleCellsForEditingMode(_ isEditing: Bool) {
+        let totalItems = snapCollectionView.numberOfItems(inSection: 0)  // 섹션이 하나이므로 0으로 고정
+        for item in 0..<totalItems {
+            let indexPath = IndexPath(item: item, section: 0)
+            if let snapCell = snapCollectionView.cellForItem(at: indexPath) as? SnapCollectionViewCell {
+                snapCell.setEditingMode(isEditing)
+            }
+        }
     }
     
     @objc private func addButtonTapped(_ sender: UIButton) {
-//        viewModel.showImagePickerActionSheet(from: self)
         let actionSheet = UIAlertController(title: "사진 선택", message: nil, preferredStyle: .actionSheet)
         
         actionSheet.addAction(UIAlertAction(title: "카메라", style: .default, handler: { _ in
@@ -353,11 +377,14 @@ class HomeViewController:
     }
     
     func showPHPicker() {
-        var configuration = PHPickerConfiguration()
-        configuration.selectionLimit = 0
-        configuration.filter = .images
+        var config = PHPickerConfiguration(photoLibrary: .shared())
+        config.filter = .images
+        config.selectionLimit = 0
+        config.selection = .ordered
+        config.preferredAssetRepresentationMode = .current
+        config.preselectedAssetIdentifiers = selectedAssetIdentifiers
         
-        let picker = PHPickerViewController(configuration: configuration)
+        let picker = PHPickerViewController(configuration: config)
         picker.delegate = self
         
         present(picker, animated: true, completion: nil)
@@ -377,20 +404,50 @@ class HomeViewController:
     
     @objc private func deleteButtonTapped(_ sender: UIButton) {
         let index = sender.tag
-        //viewModel.deleteSnap(at: index)
-        //snapCollectionView.deleteItems(at: [IndexPath(item: index, section: 0)])
+        
+        guard let categoryId = UserDefaults.standard.string(forKey: "currentCategoryId"), let snap = viewModel.snap else {
+            return // categoryId가 nil인 경우, cropImage 메서드를 종료
+        }
+        
+        let imageUrl = snap.imageUrls[index]
+        
+        viewModel.deletePhoto(categoryId: categoryId, snap: snap, imageUrlToDelete: imageUrl) { result in
+            switch result {
+            case .success:
+                self.viewModel.snap?.imageUrls.remove(at: index) // 뷰모델의 snap객체에서 삭제할 사진 제거
+                
+                if self.viewModel.snap?.imageUrls.isEmpty == true {
+                    self.viewModel.deleteSnap(categoryId: categoryId, snap: snap)
+                    self.viewModel.snap = nil
+                }
+                
+                self.snapCollectionView.performBatchUpdates({
+                    self.snapCollectionView.deleteItems(at: [IndexPath(item: index, section: 0)]) // 컬렉션뷰에서 인덱스로 삭제
+                }) { _ in
+                    // 삭제 후 나머지 셀들이 있다면 태그 업데이트
+                    if self.viewModel.snap != nil {
+                        self.updateCellTags()
+                    }
+                }
+                print("사진 삭제 성공")
+            case .failure(let error):
+                print("사진 삭제 실패: \(error.localizedDescription)")
+            }
+        }
+    }
+    
+    // 사진 삭제 후 바뀐 셀들의 인덱스에 맞게 태그를 다시 설정하는 함수
+    private func updateCellTags() {
+        let totalItems = snapCollectionView.numberOfItems(inSection: 0)  // 섹션이 하나이므로 0번째 섹션 사용
+        for item in 0..<totalItems {
+            let indexPath = IndexPath(item: item, section: 0)
+            if let snapCell = snapCollectionView.cellForItem(at: indexPath) as? SnapCollectionViewCell {
+                snapCell.deleteButton.tag = item
+            }
+        }
     }
     
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
-//        picker.dismiss(animated: true, completion: nil)
-//        
-//        if let image = info[.originalImage] as? UIImage {
-//            self.selectedImage = image
-////            self.presentImageCropper(with: info[.phAsset] as? PHAsset)
-//            print("사진 로드 성공")
-//        } else {
-//            print("사진 로드 실패")
-//        }
         if let image = info[.originalImage] as? UIImage {
             PHPhotoLibrary.shared().performChanges({
                 PHAssetChangeRequest.creationRequestForAsset(from: image)
@@ -409,11 +466,76 @@ class HomeViewController:
         picker.dismiss(animated: true, completion: nil)
     }
     
+    private func displayImage() {
+        let group = DispatchGroup()
+        var imagesDict = [String: UIImage]()
+        
+        for (identifier, result) in selections {
+            group.enter()
+            
+            let itemProvider = result.itemProvider
+            if itemProvider.canLoadObject(ofClass: UIImage.self) {
+                itemProvider.loadObject(ofClass: UIImage.self) { image, error in
+                    guard let image = image as? UIImage else { return }
+                    imagesDict[identifier] = image
+                    group.leave()
+                }
+            }
+        }
+        
+        group.notify(queue: .main) { [weak self] in
+            guard let self = self else { return }
+            var images: [UIImage] = []
+            
+            for identifier in selectedAssetIdentifiers {
+                guard let image = imagesDict[identifier] else { return }
+                images.append(image)
+            }
+            
+            guard let categoryId = UserDefaults.standard.string(forKey: "currentCategoryId") else {
+                return // categoryId가 nil인 경우, cropImage 메서드를 종료
+            }
+            
+            if let snap = viewModel.snap {
+                self.viewModel.updateSnap(categoryId: categoryId, snap: snap, newImages: images) { result in
+                    switch result {
+                    case .success(let snap):
+                        print("Snap 업데이트 성공")
+                        self.viewModel.snap = snap
+                        
+                        // 업데이트 후 데이터 로드 (임시)
+                        self.viewModel.loadSnap(categoryId: categoryId, snapDate: snap.createdAt ?? Date()) { [weak self] in
+                            DispatchQueue.main.async {
+                                self?.snapCollectionView.reloadData()
+                            }
+                        }
+                    case .failure(let error):
+                        print("Snap 업데이트 실패: \(error.localizedDescription)")
+                    }
+                }
+            } else {
+                self.viewModel.saveSnap(images: images, categoryId: categoryId) { result in
+                    switch result {
+                    case .success(let snap):
+                        print("Snap 저장 성공")
+                        self.viewModel.snap = snap
+                        
+                        // 저장 후 데이터 로드 (임시)
+                        self.viewModel.loadSnap(categoryId: categoryId, snapDate: snap.createdAt ?? Date()) { [weak self] in
+                            DispatchQueue.main.async {
+                                self?.snapCollectionView.reloadData()
+                            }
+                        }
+                    case .failure(let error):
+                        print("Snap 저장 실패: \(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+    }
+    
     // PHPickerViewControllerDelegate method
     func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
-        var images: [UIImage] = []
-        let group = DispatchGroup()
-        
         picker.dismiss(animated: true, completion: nil)
         
         guard !results.isEmpty else {
@@ -421,36 +543,18 @@ class HomeViewController:
             return
         }
         
+        var newSelections = [String: PHPickerResult]()
+        
         for result in results {
-            if result.itemProvider.canLoadObject(ofClass: UIImage.self) {
-                group.enter()
-                result.itemProvider.loadObject(ofClass: UIImage.self) { [weak self] image, _ in
-                    DispatchQueue.main.async {
-                        guard let self = self, let image = image as? UIImage else { return }
-                        images.append(image)
-                        group.leave()
-                    }
-                }
-            }
+            let identifier = result.assetIdentifier!
+            newSelections[identifier] = selections[identifier] ?? result
         }
         
-        group.notify(queue: .main) {
-            guard let categoryId = UserDefaults.standard.string(forKey: "currentCategoryId") else {
-                return // categoryId가 nil인 경우, cropImage 메서드를 종료
-            }
-            
-            self.viewModel.saveSnap(images: images, categoryId: categoryId) { result in
-                switch result {
-                case .success(let snap):
-                    print("Snap 저장 성공")
-                    self.viewModel.snapData = snap
-                    DispatchQueue.main.async {
-                        self.snapCollectionView.reloadData()
-                    }
-                case .failure(let error):
-                    print("Snap 저장 실패: \(error.localizedDescription)")
-                }
-            }
+        selections = newSelections
+        selectedAssetIdentifiers = results.compactMap { $0.assetIdentifier }
+        
+        if !selections.isEmpty {
+            displayImage()
         }
     }
     
@@ -462,7 +566,7 @@ class HomeViewController:
         cropViewController.modalPresentationStyle = .fullScreen
         
         cropViewController.didGetCroppedImage = { [weak self] (snap: Snap) in
-            self?.viewModel.snapData = snap
+            self?.viewModel.snap = snap
 //            self?.viewModel.snapData.append(snap) // Snap 객체를 viewModel에 추가
             self?.snapCollectionView.reloadData() // SnapCollectionView를 업데이트
         }

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -340,8 +340,7 @@ class HomeViewController:
         
         cropViewController.didGetCroppedImage = { [weak self] (snap: Snap) in
             self?.viewModel.snapData.append(snap) // Snap 객체를 viewModel에 추가
-            // SnapCollectionView를 업데이트
-            self?.snapCollectionView.reloadData()
+            self?.snapCollectionView.reloadData() // SnapCollectionView를 업데이트
         }
         
         present(cropViewController, animated: true, completion: nil)

--- a/SnapPop/Views/Home/SnapCollectionViewCell.swift
+++ b/SnapPop/Views/Home/SnapCollectionViewCell.swift
@@ -80,18 +80,6 @@ class SnapCollectionViewCell: UICollectionViewCell {
         
         // 편집 모드에 따라 삭제 버튼 표시
         setEditingMode(isEditing)
-//        // PHAssetIdentifier를 사용하여 PHAsset을 가져옵니다.
-//        if let firstImageUrl = snap.imageUrls.first {
-//            let url = URL(string: firstImageUrl)
-//            snapImageView.load(url: url!)
-////            if let asset = fetchPHAsset(for: firstImageUrl) {
-////                loadImage(from: asset)
-////            } else {
-////                snapImageView.image = nil // PHAsset을 찾을 수 없는 경우
-////            }
-//        } else {
-//            snapImageView.image = nil // 이미지 URL이 없는 경우
-//        }
     }
     
     func setEditingMode(_ isEditing: Bool) {

--- a/SnapPop/Views/Home/SnapCollectionViewCell.swift
+++ b/SnapPop/Views/Home/SnapCollectionViewCell.swift
@@ -73,11 +73,10 @@ class SnapCollectionViewCell: UICollectionViewCell {
     
     override func prepareForReuse() {
         super.prepareForReuse()
-        
-        // 셀의 UI를 초기 상태로 되돌립니다.
-//        snapImageView.image = UIImage()
-//        deleteButton.isHidden = true
-//        deleteButton.tag = 0
+        // 셀의 상태 초기화
+        snapImageView.image = nil
+        contentView.layer.borderWidth = 0
+        contentView.layer.borderColor = nil
     }
     
     func configure(with snap: Snap, index: Int, isFirst: Bool, isEditing: Bool) {

--- a/SnapPop/Views/Home/SnapCollectionViewCell.swift
+++ b/SnapPop/Views/Home/SnapCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Photos
 
 class SnapCollectionViewCell: UICollectionViewCell {
     
@@ -69,43 +70,33 @@ class SnapCollectionViewCell: UICollectionViewCell {
         // 편집 모드에 따라 삭제 버튼 표시
         deleteButton.isHidden = !isEditing
         
-        // Load the image from the first URL in the imageUrls array
-        if let imageUrlString = snap.imageUrls.first {
-            // Load the image using the original URL
-            loadImage(from: imageUrlString)
+        // PHAssetIdentifier를 사용하여 PHAsset을 가져옵니다.
+        if let firstImageUrl = snap.imageUrls.first {
+            if let asset = fetchPHAsset(for: firstImageUrl) {
+                loadImage(from: asset)
+            } else {
+                snapImageView.image = nil // PHAsset을 찾을 수 없는 경우
+            }
         } else {
-            snapImageView.image = nil
+            snapImageView.image = nil // 이미지 URL이 없는 경우
         }
     }
     
-    private func loadImage(from urlString: String) {
-        guard let url = URL(string: urlString) else {
-            print("Invalid URL: \(urlString)") // URL 확인
-            snapImageView.image = nil
-            return
-        }
-        
-        let task = URLSession.shared.dataTask(with: url) { data, response, error in
-            if let error = error {
-                print("Error fetching image: \(error.localizedDescription)") // 에러 확인
-                DispatchQueue.main.async {
-                    self.snapImageView.image = nil
-                }
-                return
-            }
-            
-            guard let data = data, let image = UIImage(data: data) else {
-                print("Failed to load image data.") // 데이터 확인
-                DispatchQueue.main.async {
-                    self.snapImageView.image = nil
-                }
-                return
-            }
-            
+    private func fetchPHAsset(for identifier: String) -> PHAsset? {
+        let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil)
+        return fetchResult.firstObject
+    }
+    
+    private func loadImage(from asset: PHAsset) {
+        let imageManager = PHImageManager.default()
+        let requestOptions = PHImageRequestOptions()
+        requestOptions.isSynchronous = true // 동기 요청
+        requestOptions.deliveryMode = .highQualityFormat
+
+        imageManager.requestImage(for: asset, targetSize: snapImageView.bounds.size, contentMode: .aspectFill, options: requestOptions) { [weak self] image, _ in
             DispatchQueue.main.async {
-                self.snapImageView.image = image
+                self?.snapImageView.image = image
             }
         }
-        task.resume()
     }
 }

--- a/SnapPop/Views/Home/SnapCollectionViewCell.swift
+++ b/SnapPop/Views/Home/SnapCollectionViewCell.swift
@@ -8,6 +8,20 @@
 import UIKit
 import Photos
 
+extension UIImageView {
+    func load(url: URL) {
+        DispatchQueue.global().async { [weak self] in
+            if let data = try? Data(contentsOf: url) {
+                if let image = UIImage(data: data) {
+                    DispatchQueue.main.async {
+                        self?.image = image
+                    }
+                }
+            }
+        }
+    }
+}
+
 class SnapCollectionViewCell: UICollectionViewCell {
     
     let snapImageView: UIImageView = {
@@ -57,7 +71,16 @@ class SnapCollectionViewCell: UICollectionViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    func configure(with snap: Snap, isFirst: Bool, isEditing: Bool) {
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        // 셀의 UI를 초기 상태로 되돌립니다.
+//        snapImageView.image = UIImage()
+//        deleteButton.isHidden = true
+//        deleteButton.tag = 0
+    }
+    
+    func configure(with snap: Snap, index: Int, isFirst: Bool, isEditing: Bool) {
         // 첫 번째 셀의 테두리 설정
         if isFirst {
             contentView.layer.borderWidth = 3
@@ -67,19 +90,27 @@ class SnapCollectionViewCell: UICollectionViewCell {
             contentView.layer.borderColor = nil
         }
         
-        // 편집 모드에 따라 삭제 버튼 표시
-        deleteButton.isHidden = !isEditing
+        let url = URL(string: snap.imageUrls[index])
+        snapImageView.load(url: url!)
         
-        // PHAssetIdentifier를 사용하여 PHAsset을 가져옵니다.
-        if let firstImageUrl = snap.imageUrls.first {
-            if let asset = fetchPHAsset(for: firstImageUrl) {
-                loadImage(from: asset)
-            } else {
-                snapImageView.image = nil // PHAsset을 찾을 수 없는 경우
-            }
-        } else {
-            snapImageView.image = nil // 이미지 URL이 없는 경우
-        }
+        // 편집 모드에 따라 삭제 버튼 표시
+        setEditingMode(isEditing)
+//        // PHAssetIdentifier를 사용하여 PHAsset을 가져옵니다.
+//        if let firstImageUrl = snap.imageUrls.first {
+//            let url = URL(string: firstImageUrl)
+//            snapImageView.load(url: url!)
+////            if let asset = fetchPHAsset(for: firstImageUrl) {
+////                loadImage(from: asset)
+////            } else {
+////                snapImageView.image = nil // PHAsset을 찾을 수 없는 경우
+////            }
+//        } else {
+//            snapImageView.image = nil // 이미지 URL이 없는 경우
+//        }
+    }
+    
+    func setEditingMode(_ isEditing: Bool) {
+        deleteButton.isHidden = !isEditing
     }
     
     private func fetchPHAsset(for identifier: String) -> PHAsset? {

--- a/SnapPop/Views/Home/SnapCollectionViewCell.swift
+++ b/SnapPop/Views/Home/SnapCollectionViewCell.swift
@@ -8,20 +8,6 @@
 import UIKit
 import Photos
 
-extension UIImageView {
-    func load(url: URL) {
-        DispatchQueue.global().async { [weak self] in
-            if let data = try? Data(contentsOf: url) {
-                if let image = UIImage(data: data) {
-                    DispatchQueue.main.async {
-                        self?.image = image
-                    }
-                }
-            }
-        }
-    }
-}
-
 class SnapCollectionViewCell: UICollectionViewCell {
     
     let snapImageView: UIImageView = {

--- a/SnapPop/Views/Root/CustomTabBarController.swift
+++ b/SnapPop/Views/Root/CustomTabBarController.swift
@@ -36,7 +36,8 @@ class CustomTabBarController: UITabBarController {
             selectedImage: UIImage(systemName: "calendar.fill")
         )
         
-        let secondViewController = HomeViewController()
+        let customNavViewModel = CustomNavigationBarViewModel()
+        let secondViewController = HomeViewController(navigationBarViewModel: customNavViewModel)
         secondViewController.tabBarItem = UITabBarItem(
             title: "",
             image: UIImage(systemName: "house"),

--- a/SnapPop/Views/SnapComparison/Cells/HorizontalSnapPhotoCollectionViewCell.swift
+++ b/SnapPop/Views/SnapComparison/Cells/HorizontalSnapPhotoCollectionViewCell.swift
@@ -14,7 +14,7 @@ class HorizontalSnapPhotoCollectionViewCell: UICollectionViewCell {
 
     /// 스냅 사진
     lazy var snapPhoto: UIImageView = {
-        let image = UIImageView(image: UIImage(systemName: "person.fill"))
+        let image = UIImageView()
         image.translatesAutoresizingMaskIntoConstraints = false
         return image
     }()
@@ -27,6 +27,12 @@ class HorizontalSnapPhotoCollectionViewCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        // 셀의 상태 초기화
+        snapPhoto.image = nil
+        snapPhoto.layer.borderColor = nil
     }
     
     // MARK: - Methods

--- a/SnapPop/Views/SnapComparison/Cells/HorizontalSnapPhotoCollectionViewCell.swift
+++ b/SnapPop/Views/SnapComparison/Cells/HorizontalSnapPhotoCollectionViewCell.swift
@@ -28,12 +28,6 @@ class HorizontalSnapPhotoCollectionViewCell: UICollectionViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    override func prepareForReuse() {
-        super.prepareForReuse()
-        // 셀의 상태 초기화
-        snapPhoto.image = nil
-        snapPhoto.layer.borderColor = nil
-    }
     
     // MARK: - Methods
     private func setupLayout() {

--- a/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
+++ b/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
@@ -77,12 +77,20 @@ class SnapComparisonCollectionViewCell: UICollectionViewCell {
     }
     
     func configure(with viewModel: SnapComparisonCellViewModelProtocol, data: Snap, filteredData: [Snap], sectionIndex: Int) {
+        guard let date = data.createdAt else { return }
         self.viewModel = viewModel
         self.viewModel?.snapPhotos = data.imageUrls
         self.viewModel?.currentSectionIndex = sectionIndex
         self.viewModel?.filteredSnapData = filteredData
-        snapCellDateLabel.text = "\(String(describing: data.createdAt))"
+        snapCellDateLabel.text = updateDate(to: date)
         horizontalSnapPhotoCollectionView.reloadData()
+    }
+    
+    func updateDate(to date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 d일"
+        let updatedDateString = formatter.string(from: date)
+        return updatedDateString
     }
 }
 

--- a/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
+++ b/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 class SnapComparisonCollectionViewCell: UICollectionViewCell {
     
@@ -100,7 +101,7 @@ extension SnapComparisonCollectionViewCell: UICollectionViewDelegate, UICollecti
         
         let imageUrlString = viewModel.snapPhotos[indexPath.row]
         if let imageUrl = URL(string: imageUrlString) {
-            cell.snapPhoto.load(from: imageUrl)
+            cell.snapPhoto.kf.setImage(with: imageUrl, placeholder: UIImage(systemName: "circle.dotted"))
         }
         
         if indexPath.row == 0 {

--- a/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
+++ b/SnapPop/Views/SnapComparison/Cells/SnapComparisonCollectionViewCell.swift
@@ -26,8 +26,8 @@ class SnapComparisonCollectionViewCell: UICollectionViewCell {
     lazy var horizontalSnapPhotoCollectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.minimumLineSpacing = 0
-        layout.minimumInteritemSpacing = 0
+        layout.minimumLineSpacing = 10
+        layout.minimumInteritemSpacing = 10
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: layout)
         collectionView.delegate = self
         collectionView.dataSource = self
@@ -75,12 +75,12 @@ class SnapComparisonCollectionViewCell: UICollectionViewCell {
         
     }
     
-    func configure(with viewModel: SnapComparisonCellViewModelProtocol, data: MockSnap, filteredData: [MockSnap], sectionIndex: Int) {
+    func configure(with viewModel: SnapComparisonCellViewModelProtocol, data: Snap, filteredData: [Snap], sectionIndex: Int) {
         self.viewModel = viewModel
-        self.viewModel?.snapPhotos = data.images
+        self.viewModel?.snapPhotos = data.imageUrls
         self.viewModel?.currentSectionIndex = sectionIndex
         self.viewModel?.filteredSnapData = filteredData
-        snapCellDateLabel.text = data.date
+        snapCellDateLabel.text = "\(String(describing: data.createdAt))"
         horizontalSnapPhotoCollectionView.reloadData()
     }
 }
@@ -98,17 +98,20 @@ extension SnapComparisonCollectionViewCell: UICollectionViewDelegate, UICollecti
             return UICollectionViewCell()
         }
         
-        cell.snapPhoto.image = viewModel.snapPhotos[indexPath.row]
+        let imageUrlString = viewModel.snapPhotos[indexPath.row]
+        if let imageUrl = URL(string: imageUrlString) {
+            cell.snapPhoto.load(from: imageUrl)
+        }
         
         if indexPath.row == 0 {
-            // 절대값 수정 해야할듯
-            cell.snapPhoto.layer.borderColor = UIColor(red: 0.57, green: 0.87, blue: 0.91, alpha: 1.00).cgColor
+            cell.snapPhoto.layer.borderColor = UIColor.customMainColor?.cgColor
             cell.snapPhoto.layer.borderWidth = 3
             cell.snapPhoto.layer.cornerRadius = 30
             cell.snapPhoto.layer.masksToBounds = true
         } else {
             cell.snapPhoto.layer.borderWidth = 0.0
             cell.snapPhoto.layer.cornerRadius = 30
+            cell.snapPhoto.layer.masksToBounds = true
         }
         
         return cell

--- a/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
@@ -50,7 +50,7 @@ class SnapComparisonSheetViewController: UIViewController {
     /// 페이지 컨트롤
     private lazy var pageControl: UIPageControl = {
         let pageControl = UIPageControl()
-        pageControl.numberOfPages = viewModel.currentSnap.images.count
+        pageControl.numberOfPages = viewModel.currentSnap.imageUrls.count
         pageControl.currentPage = viewModel.currentPhotoIndex
         pageControl.currentPageIndicatorTintColor = .black
         pageControl.pageIndicatorTintColor = .systemGray5
@@ -156,8 +156,8 @@ class SnapComparisonSheetViewController: UIViewController {
     }
     
     private func updateUI() {
-        snapDateLabel.text = viewModel.currentSnap.date
-        pageControl.numberOfPages = viewModel.currentSnap.images.count
+        snapDateLabel.text = "\(String(describing: viewModel.currentSnap.createdAt))"
+        pageControl.numberOfPages = viewModel.currentSnap.imageUrls.count
         pageControl.currentPage = viewModel.currentPhotoIndex
         
         // 화살표 버튼 숨김

--- a/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
@@ -166,10 +166,13 @@ class SnapComparisonSheetViewController: UIViewController {
     }
     /// 인덱스에 해당하는 SnapPhotoViewController 나타내는 메소드
     private func viewControllerAt(index: Int) -> UIViewController? {
-        guard let image = viewModel.getSnapPhoto(at: index) else { return nil }
         let photoViewController = SnapPhotoViewController()
-        photoViewController.image = image
         photoViewController.index = index
+        self.viewModel.getSnapPhoto(at: index) { image in
+            DispatchQueue.main.async {
+                photoViewController.image = image
+            }
+        }
         return photoViewController
     }
     

--- a/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonSheetViewController.swift
@@ -156,7 +156,7 @@ class SnapComparisonSheetViewController: UIViewController {
     }
     
     private func updateUI() {
-        snapDateLabel.text = "\(String(describing: viewModel.currentSnap.createdAt))"
+        snapDateLabel.text = viewModel.getDateString()
         pageControl.numberOfPages = viewModel.currentSnap.imageUrls.count
         pageControl.currentPage = viewModel.currentPhotoIndex
         
@@ -169,12 +169,12 @@ class SnapComparisonSheetViewController: UIViewController {
         let photoViewController = SnapPhotoViewController()
         photoViewController.index = index
         self.viewModel.getSnapPhoto(at: index) { image in
-            DispatchQueue.main.async {
-                photoViewController.image = image
-            }
+            photoViewController.image = image
         }
         return photoViewController
     }
+    
+    // MARK: - Actions
     
     @objc private func didTapLeftArrow() {
         viewModel.moveToPreviousSnap()
@@ -200,13 +200,15 @@ extension SnapComparisonSheetViewController: UIPageViewControllerDelegate, UIPag
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         guard let viewController = viewController as? SnapPhotoViewController else { return nil }
-        let index = viewController.index
-        return viewControllerAt(index: index - 1)
+        let index = viewController.index - 1
+        guard index > 0 else { return nil }
+        return viewControllerAt(index: index )
     }
     
     func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
         guard let viewController = viewController as? SnapPhotoViewController else { return nil }
-        let index = viewController.index + 1
+        let index = viewController.index  + 1
+        guard index < viewModel.currentSnap.imageUrls.count else { return nil }
         return viewControllerAt(index: index)
     }
     

--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -52,6 +52,20 @@ class SnapComparisonViewController: UIViewController {
         return button
     }()
     
+    /// 기준 스냅 선택 버튼
+    private lazy var selectSnapDateButton: UIButton = {
+        var buttonConfig = UIButton.Configuration.filled()
+        buttonConfig.title = "날짜 선택"
+        buttonConfig.image = UIImage(systemName: "calendar")
+        buttonConfig.imagePadding = 5
+        buttonConfig.baseBackgroundColor = UIColor.customButtonColor
+        buttonConfig.baseForegroundColor = .black
+        buttonConfig.background.cornerRadius = 8
+        let button = UIButton(configuration: buttonConfig)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     /// 스냅 콜렉션 뷰
     private lazy var collectionView: UICollectionView = {
         let layout = UICollectionViewFlowLayout()
@@ -117,6 +131,7 @@ class SnapComparisonViewController: UIViewController {
         view.addSubviews([
             selectSnapPhotoButton,
             selectSnapPeriodButton,
+            selectSnapDateButton,
             collectionView,
             snapAndCategoryCheckLabel
         ])
@@ -126,7 +141,10 @@ class SnapComparisonViewController: UIViewController {
             selectSnapPeriodButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10),
             
             selectSnapPhotoButton.topAnchor.constraint(equalTo: selectSnapPeriodButton.topAnchor),
-            selectSnapPhotoButton.trailingAnchor.constraint(equalTo: selectSnapPeriodButton.leadingAnchor, constant: -10),
+            selectSnapPhotoButton.trailingAnchor.constraint(equalTo: selectSnapPeriodButton.leadingAnchor, constant: -5),
+            
+            selectSnapDateButton.topAnchor.constraint(equalTo: selectSnapPhotoButton.topAnchor),
+            selectSnapDateButton.trailingAnchor.constraint(equalTo: selectSnapPhotoButton.leadingAnchor, constant: -5),
             
             collectionView.topAnchor.constraint(equalTo: selectSnapPhotoButton.bottomAnchor, constant: 10),
             collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
@@ -151,6 +169,9 @@ class SnapComparisonViewController: UIViewController {
         selectSnapPeriodButton.menu = selectPeriodMenu
         selectSnapPeriodButton.showsMenuAsPrimaryAction = true
         
+        let selectDateMenu = UIMenu(title: "날짜 선택", children: viewModel.snapDateMenuItems)
+        selectSnapDateButton.menu = selectDateMenu
+        selectSnapDateButton.showsMenuAsPrimaryAction = true
     }
     
     func setupBindings() {
@@ -162,6 +183,9 @@ class SnapComparisonViewController: UIViewController {
         }
         viewModel.updateSnapPeriodButtonTitle = { [weak self] title in
             self?.selectSnapPeriodButton.setTitle(title, for: .normal)
+        }
+        viewModel.updateSnapDateButtonTitle = { [weak self] title in
+            self?.selectSnapDateButton.setTitle(title, for: .normal)
         }
         viewModel.categoryisEmpty = {
             self.collectionView.isHidden = true

--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -109,7 +109,7 @@ class SnapComparisonViewController: UIViewController {
         if let currentCategoryId = UserDefaults.standard.string(forKey: "currentCategoryId") {
             viewModel.loadSanpstoFireStore(to: currentCategoryId)
         }
-        print("ViewWIllApear")
+        reloadCollectionView()        
     }
     
     // MARK: - Methods

--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -6,29 +6,6 @@
 //
 
 import UIKit
-// TODO: - 익스텐션 파일로 분할
-extension UIImageView {
-    func load(from url: URL) {
-        DispatchQueue.global().async { [weak self] in
-            if let data = try? Data(contentsOf: url) {
-                if let image = UIImage(data: data) {
-                    DispatchQueue.main.async {
-                        self?.image = image
-                    }
-                }
-            }
-        }
-    }
-}
-
-extension UIImage {
-    static func loadImage(from url: URL) -> UIImage? {
-        if let data = try? Data(contentsOf: url) {
-            return UIImage(data: data)
-        }
-        return nil
-    }
-}
 
 class SnapComparisonViewController: UIViewController {
     

--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -96,7 +96,6 @@ class SnapComparisonViewController: UIViewController {
         
         if let currentCategoryId = UserDefaults.standard.string(forKey: "currentCategoryId") {
             viewModel.loadSanpstoFireStore(to: currentCategoryId)
-            viewModel.filterSnaps()
         }
         
         if let navigationController = self.navigationController as? CustomNavigationBarController {

--- a/SnapPop/Views/SnapComparison/SnapPhotoViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapPhotoViewController.swift
@@ -35,7 +35,13 @@ class SnapPhotoViewController: UIViewController {
         ])
         
         if let image = image {
-            imageView.image = image
+            DispatchQueue.main.async {
+                self.imageView.image = image
+                self.imageView.layer.borderColor = UIColor.lightGray.cgColor
+                self.imageView.layer.borderWidth = 1
+                self.imageView.layer.cornerRadius = 50
+                self.imageView.layer.masksToBounds = true
+            }
         } else {
             print("nil Image")
         }

--- a/SnapPop/Views/SnapComparison/SnapPhotoViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapPhotoViewController.swift
@@ -10,7 +10,11 @@ import UIKit
 class SnapPhotoViewController: UIViewController {
     
     // MARK: - Properties
-    var image: UIImage?
+    var image: UIImage? {
+        didSet {
+            updateImage()
+        }
+    }
     var index: Int = 0
     
     // MARK: - UIComponents
@@ -21,7 +25,7 @@ class SnapPhotoViewController: UIViewController {
         return imageView
     }()
     
-    // MARK: = LifeCycle
+    // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -34,6 +38,11 @@ class SnapPhotoViewController: UIViewController {
             imageView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
         
+        updateImage()
+    }
+    
+    //MARK: - Methods
+    private func updateImage() {
         if let image = image {
             DispatchQueue.main.async {
                 self.imageView.image = image


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 킹피셔 라이브러리 사용하여 동적으로 이미지 보여주기.
- [x] 날자 년원일 형식으로 보여주기
- [x] SnapService의 loadSnaps 오름차순으로 가져오기. 
- [x] 카테고리 변경시 해당 카테고리의 스냅 불러오기.
- [x] 스냅 비교 주기 추가: 스냅 비교 주기 버튼에서 선택된 날자를 간격을 기준으로 저장되어있는 스냅을 보여줌 

### 📸 스크린샷


https://github.com/user-attachments/assets/c47396a5-d46f-448e-83bf-6e075b88e896

[2024.08.26,
2024.08.18,
2024.08.12,
2024.08.05,
2024.01.01]
의 날짜(createdAt)의 데이터를 가지고 있음. 
2024.01.01과 한달을 주기로 보여준다면 2024.01.01과 2024.08 .05가 보여지게 됨.

### 🛠️ 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [ ] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- 특이 사항 1
- 이제 카테고리 삭제하면 스냅도 같이 삭제하는 것을 추가해보도록 하겠습니다.
- 특이사항 2
- 저 지금 허리에 담와서 앉아있기 힘듬 숨이 안쉬어져요

<br/><br/>