### PR TITLE
Feature/custom nav

### DIFF
--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -222,6 +222,12 @@ final class SnapService {
         loadSnaps(categoryId: categoryId) { result in
             switch result {
             case .success(let snaps):
+                
+                guard !snaps.isEmpty else {
+                    completion(nil)// 스냅이 없는 경우 바로 카테고리 삭제
+                    return
+                }
+                
                 for snap in snaps {
                     for imageUrl in snap.imageUrls {
                         self.deleteImage(categoryId: categoryId, snap: snap, imageUrlToDelete: imageUrl) { result in
@@ -230,7 +236,6 @@ final class SnapService {
                                 print("[SnapService] Success to deleteImage")
                             case .failure(let error):
                                 print("[SnapService] Failed to deleteImage: \(error.localizedDescription)")
-                                completion(error)
                             }
                         }
                     }
@@ -243,7 +248,7 @@ final class SnapService {
                         .document(snapId)
                         .delete { error in
                             if let error = error {
-                                completion(error)
+                                print("[SnapService] Failed to deleteSnap: \(error.localizedDescription)")
                             } else {
                                 completion(nil)
                             }
@@ -252,7 +257,7 @@ final class SnapService {
                 }
             case .failure(let error):
                 print("[SnapService] Failed to load snaps: \(error.localizedDescription)")
-                completion(error)
+                completion(nil)
             }
         }
     }

--- a/SnapPop/ViewModels/Root/CustomNavigationBarViewModel.swift
+++ b/SnapPop/ViewModels/Root/CustomNavigationBarViewModel.swift
@@ -108,7 +108,6 @@ class CustomNavigationBarViewModel: CustomNavigationBarViewModelProtocol {
                         if self.currentCategory?.id == categoryId {
                             if self.categories.isEmpty {
                                 // 카테고리가 남아있지 않은 경우
-                                // documentPath Error 발생위치
                                 self.currentCategory = nil
                                 UserDefaults.standard.removeObject(forKey: "currentCategoryId")
                                 print("카테고리가 남아있지 않은 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
@@ -143,11 +142,13 @@ class CustomNavigationBarViewModel: CustomNavigationBarViewModelProtocol {
                                 completion("카테고리를 추가해 주세요")
                             }
                         }
-                        self.categoryisUpdated?()
                     }
                 }
             }
-        }
+            
+        } // deleteSnaps
+        
+        self.categoryisUpdated?()
     }
     
     func selectCategory(at index: Int) {
@@ -158,7 +159,7 @@ class CustomNavigationBarViewModel: CustomNavigationBarViewModelProtocol {
         self.currentCategory = categories[index]
         print("selectCategory Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
     }
-        
+    
     func handleCategoryId(completion: @escaping (String) -> Void) {
         loadCategories { [weak self] in
             guard let self = self else { return }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -34,10 +34,10 @@ protocol SnapComparisonViewModelProtocol {
     func numberOfRows(in section: Int) -> Int
     func loadSanpstoFireStore(to categoryId: String)
     func filterSnapsByPeriod(_ snaps: [Snap], periodType: String) -> [Snap]
+    func categoryDidChange(to newCategoryId: String?)
 }
 
-class SnapComparisonViewModel: SnapComparisonViewModelProtocol,
-                               CategoryChangeDelegate {
+class SnapComparisonViewModel: SnapComparisonViewModelProtocol {
     
     // MARK: - Properties
     private let snapService = SnapService()

--- a/SnapPop/Views/Root/CategorySettingsViewController.swift
+++ b/SnapPop/Views/Root/CategorySettingsViewController.swift
@@ -168,8 +168,6 @@ class CategorySettingsViewController: UIViewController {
                     self.viewModel.categoryisUpdated?()
                 }
                 categoryTextField.text = ""
-               
-                
             } else {
                 // 카테고리가 있는 경우
                 let newCategory = Category(userId: "\(AuthViewModel.shared.currentUser?.uid ?? "")", title: "\(categoryName)", alertStatus: true)
@@ -253,6 +251,7 @@ extension CategorySettingsViewController: UITableViewDelegate, UITableViewDataSo
         
         let trash = UIContextualAction(style: .normal, title: "") { (_, _, success: @escaping (Bool) -> Void) in
             self.viewModel.deleteCategory(at: indexPath.row) { newTitle in
+                guard let newTitle = newTitle else { return }
                 DispatchQueue.main.async {
                     self.categoryTable.reloadData()
                 }
@@ -262,7 +261,7 @@ extension CategorySettingsViewController: UITableViewDelegate, UITableViewDataSo
             
             print("Current Categories: \(self.viewModel.categories)")
             print("현재 선택된 카테고리: \(self.viewModel.currentCategory?.title)")
-
+            
             success(true)
             
         }

--- a/SnapPop/Views/Root/CustomNavigationBarController.swift
+++ b/SnapPop/Views/Root/CustomNavigationBarController.swift
@@ -59,13 +59,16 @@ class CustomNavigationBarController: UINavigationController {
         if topViewController?.navigationItem.leftBarButtonItem == nil {
             setupNavigationBarItems()
         }
-//        loadCategories()
+        loadCategories()
         updateCategoryMenu()
-    }
-    
-    override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        updateCategoryMenu()
+        
+        // TODO: - categoryisUpdated를 왜 다시 정의해줘야 동작이 잘되는거지..?
+        viewModel.categoryisUpdated = { [weak self] in
+            print("CustomNavigationBarController에서 categoryisUpdated 클로저 호출됨")
+            DispatchQueue.main.async {
+                self?.updateCategoryMenu()
+            }
+        }
     }
     
     // MARK: - Methods

--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -120,10 +120,16 @@ class SnapComparisonViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self, name: .categoryDidChange, object: nil)
+    }
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         
         self.view.backgroundColor = .customBackground
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(categoryDidChange(_:)), name: .categoryDidChange, object: nil)
         
         setupBindings()
         setupLayout()
@@ -133,9 +139,9 @@ class SnapComparisonViewController: UIViewController {
             viewModel.loadSanpstoFireStore(to: currentCategoryId)
         }
         
-        if let navigationController = self.navigationController as? CustomNavigationBarController {
-            navigationController.viewModel.delegate = viewModel as? CategoryChangeDelegate
-        }
+//        if let navigationController = self.navigationController as? CustomNavigationBarController {
+//            navigationController.viewModel.delegate = viewModel as? CategoryChangeDelegate
+//        }
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -232,6 +238,16 @@ class SnapComparisonViewController: UIViewController {
     func reloadCollectionView() {
         DispatchQueue.main.async {
             self.collectionView.reloadData()
+        }
+    }
+    
+    @objc private func categoryDidChange(_ notification: Notification) {
+        if let userInfo = notification.userInfo, let categoryId = userInfo["categoryId"] as? String {
+            print("[스냅 비교뷰] 카테고리가 변경되었습니다: \(categoryId)")
+            viewModel.categoryDidChange(to: categoryId)
+        } else {
+            print("카테고리가 없습니다.")
+            viewModel.categoryDidChange(to: nil)
         }
     }
 }


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 네비게이션 카테고리 타이을 변경 문제 해결
- [x] 카테고리의 id 변경 감지를 델리게이트 패턴 -> NotificationCenter 로 변경

### 📸 스크린샷

### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [ ] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

### View

ViewDidLoad에서 노티피케이션센터 구독
`
override func viewDidLoad() {
      NotificationCenter.default.addObserver(self, selector: #selector(categoryDidChange(_:)), name: .categoryDidChange, object: nil) //구독
    }
`

deinit 에서 옵저버 삭제
`
deinit {
        NotificationCenter.default.removeObserver(self, name: .categoryDidChange, object: nil)
    }
`

노티피케이션 센터로 카테고리.id 수신 메소드 

`
@objc private func categoryDidChange(_ notification: Notification) {
    if let userInfo = notification.userInfo, let categoryId = userInfo["categoryId"] as? String {
        print("[스냅 비교뷰] 카테고리가 변경되었습니다: \(categoryId)")
        viewModel.categoryDidChange(to: categoryId)
    } else {
        print("카테고리가 없습니다.")
        viewModel.categoryDidChange(to: nil)
    }
}
`

### VM

위의 있는 메소드를 정의한다면 여러분들이 메소드를 바꿀 필요는 없어보입니다 (categoryDidChange가 VM에 정의되어있었다면)
<br/><br/>