### PR TITLE
Refactor/detail cost view

### DIFF
--- a/SnapPop.xcodeproj/project.pbxproj
+++ b/SnapPop.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		C259C8142C784610004F569A /* UIImageView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C259C8132C784610004F569A /* UIImageView+Extensions.swift */; };
 		C259C81B2C787B89004F569A /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C259C81A2C787B89004F569A /* NotificationManager.swift */; };
 		C2734C3B2C69F1D200E45294 /* CategoryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2734C3A2C69F1D200E45294 /* CategoryService.swift */; };
+		C2A6CAAB2C7EDB1100F7670A /* UITextField+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A6CAAA2C7EDB1100F7670A /* UITextField+Extensions.swift */; };
+		C2A6CAAD2C7EE2F800F7670A /* UIResponder+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2A6CAAC2C7EE2F800F7670A /* UIResponder+Extensions.swift */; };
 		C2D4015B2C73788D000E0343 /* DetailCostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */; };
 		C2D401602C73853B000E0343 /* CustomTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D4015F2C73853B000E0343 /* CustomTableViewCell.swift */; };
 		C2F081002C7D6DD600BE8B0D /* DetailCost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F080FF2C7D6DD600BE8B0D /* DetailCost.swift */; };
@@ -121,6 +123,8 @@
 		C259C8132C784610004F569A /* UIImageView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+Extensions.swift"; sourceTree = "<group>"; };
 		C259C81A2C787B89004F569A /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		C2734C3A2C69F1D200E45294 /* CategoryService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryService.swift; sourceTree = "<group>"; };
+		C2A6CAAA2C7EDB1100F7670A /* UITextField+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extensions.swift"; sourceTree = "<group>"; };
+		C2A6CAAC2C7EE2F800F7670A /* UIResponder+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Extensions.swift"; sourceTree = "<group>"; };
 		C2D4015A2C73788D000E0343 /* DetailCostViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCostViewController.swift; sourceTree = "<group>"; };
 		C2D4015F2C73853B000E0343 /* CustomTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomTableViewCell.swift; sourceTree = "<group>"; };
 		C2F080FF2C7D6DD600BE8B0D /* DetailCost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailCost.swift; sourceTree = "<group>"; };
@@ -361,6 +365,8 @@
 				4AD29AD72C6B35BE00A9BEDD /* Color+Extensions.swift */,
 				C259C8132C784610004F569A /* UIImageView+Extensions.swift */,
 				C259C81A2C787B89004F569A /* NotificationManager.swift */,
+				C2A6CAAA2C7EDB1100F7670A /* UITextField+Extensions.swift */,
+				C2A6CAAC2C7EE2F800F7670A /* UIResponder+Extensions.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -569,6 +575,7 @@
 				EA5047612C6500870033D807 /* HomeViewModel.swift in Sources */,
 				8FA215942C745B4300891F93 /* CostChartViewController.swift in Sources */,
 				C259C81B2C787B89004F569A /* NotificationManager.swift in Sources */,
+				C2A6CAAD2C7EE2F800F7670A /* UIResponder+Extensions.swift in Sources */,
 				4AD29AD52C6AE1F200A9BEDD /* UIView+Extensions.swift in Sources */,
 				C2F081002C7D6DD600BE8B0D /* DetailCost.swift in Sources */,
 				4A20F6472C6C32B600F263FF /* SnapComparisonSheetViewModel.swift in Sources */,
@@ -599,6 +606,7 @@
 				EA57EB4A2C72CAD2007F8987 /* Management.swift in Sources */,
 				8FA215912C731E0500891F93 /* TodoTableViewCell.swift in Sources */,
 				EA141F9E2C6AEAB200DD4B29 /* ChecklistTableViewCell.swift in Sources */,
+				C2A6CAAB2C7EDB1100F7670A /* UITextField+Extensions.swift in Sources */,
 				EA664E4E2C73914B0034B998 /* CustomCropToolbar.swift in Sources */,
 				EA50475B2C64A1390033D807 /* HomeViewController.swift in Sources */,
 				C246CE5A2C74EF7D00A631BE /* AccountInfoTableViewCell.swift in Sources */,

--- a/SnapPop/Common/UIResponder+Extensions.swift
+++ b/SnapPop/Common/UIResponder+Extensions.swift
@@ -1,0 +1,25 @@
+//
+//  UIResponder+Extensions.swift
+//  SnapPop
+//
+//  Created by 이인호 on 8/28/24.
+//
+
+import UIKit
+
+extension UIResponder {
+    private struct Static {
+        static weak var responder: UIResponder?
+    }
+    
+    static var currentResponder: UIResponder? {
+        Static.responder = nil
+        UIApplication.shared.sendAction(#selector(UIResponder._trap), to: nil, from: nil, for: nil)
+        
+        return Static.responder
+    }
+    
+    @objc private func _trap() {
+        Static.responder = self
+    }
+}

--- a/SnapPop/Common/UITextField+Extensions.swift
+++ b/SnapPop/Common/UITextField+Extensions.swift
@@ -1,0 +1,28 @@
+//
+//  UITextField+Extensions.swift
+//  SnapPop
+//
+//  Created by 이인호 on 8/28/24.
+//
+
+import UIKit
+
+extension UITextField {
+    func addDoneCancelToolbar(onDone: (target: Any, action: Selector)? = nil, onCancel: (target: Any, action: Selector)? = nil) {
+        let onCancel = onCancel ?? (target: self, action: #selector(cancelButtonTapped))
+        let onDone = onDone ?? (target: self, action: #selector(doneButtonTapped))
+        
+        let toolbar: UIToolbar = UIToolbar()
+        toolbar.barStyle = .default
+        toolbar.items = [
+            UIBarButtonItem(title: "취소", style: .plain, target: onCancel.target, action: onCancel.action),
+            UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: self, action: nil),
+            UIBarButtonItem(title: "완료", style: .done, target: onDone.target, action: onDone.action)
+        ]
+        toolbar.sizeToFit()
+        self.inputAccessoryView = toolbar
+    }
+    
+    @objc func doneButtonTapped() { self.resignFirstResponder() }
+    @objc func cancelButtonTapped() { self.resignFirstResponder() }
+}

--- a/SnapPop/Views/DetailCost/CustomTableViewCell.swift
+++ b/SnapPop/Views/DetailCost/CustomTableViewCell.swift
@@ -177,6 +177,7 @@ final class CalculateCostCell: BaseTableViewCell2 {
         textField.borderStyle = .roundedRect
         textField.keyboardType = .numberPad
         textField.delegate = self
+        textField.addDoneCancelToolbar(onDone: (target: self, action: #selector(doneButtonTappedForPurchasePrice)))
         
         return textField
     }()
@@ -196,6 +197,7 @@ final class CalculateCostCell: BaseTableViewCell2 {
         textField.borderStyle = .roundedRect
         textField.keyboardType = .numberPad
         textField.delegate = self
+        textField.addDoneCancelToolbar(onDone: (target: self, action: #selector(doneButtonTappedForUsageCount)))
         
         return textField
     }()
@@ -264,6 +266,14 @@ final class CalculateCostCell: BaseTableViewCell2 {
         }
         
         onCalculate?(purchasePrice / usageCount)
+    }
+    
+    @objc func doneButtonTappedForPurchasePrice() {
+        purchasePriceTextField.resignFirstResponder()
+    }
+    
+    @objc func doneButtonTappedForUsageCount() {
+        usageCountTextField.resignFirstResponder()
     }
 }
 

--- a/SnapPop/Views/DetailCost/CustomTableViewCell.swift
+++ b/SnapPop/Views/DetailCost/CustomTableViewCell.swift
@@ -41,6 +41,7 @@ final class TitleCell2: BaseTableViewCell2 {
         
         NSLayoutConstraint.activate([
             textField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             textField.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
     }
@@ -67,6 +68,7 @@ final class DescriptionCell: BaseTableViewCell2 {
         
         NSLayoutConstraint.activate([
             textField.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            textField.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
             textField.centerYAnchor.constraint(equalTo: contentView.centerYAnchor)
         ])
     }

--- a/SnapPop/Views/DetailCost/DetailCostViewController.swift
+++ b/SnapPop/Views/DetailCost/DetailCostViewController.swift
@@ -33,6 +33,10 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         return tableView
     }()
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     // MARK: - LifeCycle
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -67,7 +71,14 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         ])
         
         title = "상세내역"
-
+        
+        let appearance = UINavigationBarAppearance()
+        appearance.backgroundColor = .white
+        appearance.backgroundEffect = nil
+        appearance.shadowColor = nil
+        navigationController?.navigationBar.standardAppearance = appearance
+        navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancelButtonTapped))
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가", style: .done, target: self, action: #selector(saveButtonTapped))
         navigationItem.rightBarButtonItem?.isEnabled = false
@@ -219,8 +230,8 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         // Y축으로 텍스트필드 하단 위치가 키보드 상단 위치보다 클 때 (텍스트필드가 키보드에 가려질 때)
         if textFieldBottomY > keyboardTopY {
             let textFieldTopY = convertedTextFieldFrame.origin.y
-            let newFrame = textFieldTopY - keyboardTopY/1.6
-            view.frame.origin.y -= newFrame
+            let newFrame = (textFieldTopY - keyboardTopY / 1.6) * -1
+            view.frame.origin.y = newFrame
         }
     }
     

--- a/SnapPop/Views/DetailCost/DetailCostViewController.swift
+++ b/SnapPop/Views/DetailCost/DetailCostViewController.swift
@@ -38,6 +38,7 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         super.viewDidLoad()
         
         configureUI()
+        setupKeyboardEvent()
     }
     
     // MARK: - Methods
@@ -70,6 +71,11 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancelButtonTapped))
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "추가", style: .done, target: self, action: #selector(saveButtonTapped))
         navigationItem.rightBarButtonItem?.isEnabled = false
+    }
+    
+    func setupKeyboardEvent() {
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillHide), name: UIResponder.keyboardWillHideNotification, object: nil)
     }
     
     // MARK: - Actions
@@ -165,7 +171,6 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
             return UITableViewCell()
         }
     }
-    
     // MARK: - Keyboard Handling
 
     // 화면을 터치했을 때 키보드 내리기
@@ -196,5 +201,33 @@ class DetailCostViewController: UIViewController, UITableViewDelegate, UITableVi
         }
         
         return true
+    }
+    
+    // 키보드 올라왔을때
+    @objc func keyboardWillShow(_ sender: Notification) {
+        guard let keyboardFrame = sender.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue,
+              let currentTextField = UIResponder.currentResponder as? UITextField else { return }
+        
+        // Y축으로 키보드의 상단 위치
+        let keyboardTopY = keyboardFrame.cgRectValue.origin.y
+        // 현재 선택한 텍스트 필드의 Frame 값
+        let convertedTextFieldFrame = view.convert(currentTextField.frame,
+                                                   from: currentTextField.superview)
+        // Y축으로 현재 텍스트 필드의 하단 위치
+        let textFieldBottomY = convertedTextFieldFrame.origin.y + convertedTextFieldFrame.size.height
+        
+        // Y축으로 텍스트필드 하단 위치가 키보드 상단 위치보다 클 때 (텍스트필드가 키보드에 가려질 때)
+        if textFieldBottomY > keyboardTopY {
+            let textFieldTopY = convertedTextFieldFrame.origin.y
+            let newFrame = textFieldTopY - keyboardTopY/1.6
+            view.frame.origin.y -= newFrame
+        }
+    }
+    
+    // 키보드 내려갔을때
+    @objc func keyboardWillHide(_ sender: Notification) {
+        if view.frame.origin.y != 0 {
+            view.frame.origin.y = 0
+        }
     }
 }


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 상세 비용 넘버패드 닫을수있는 취소/완료 툴바버튼 구현
- [x] 키보드가 텍스트필드 가리는경우 화면 프레임 위로 이동되도록 구현

### 📸 스크린샷

https://github.com/user-attachments/assets/e62d3f6f-bf9e-4c5c-b02d-47e14fce658f

### 🛠️ 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [x] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- 넘버패드 완료버튼 추가 (참고 : https://stackoverflow.com/questions/38133853/how-to-add-a-return-key-on-a-decimal-pad-in-swift?answertab=scoredesc#tab-top)
- 키보드 텍스트필드 가리는거 해결 (참고 : https://github.com/jrasmusson/ios-professional-course/blob/main/Password-Reset/7-Dealing-Keyboards/README.md)

<br/><br/>