### PR TITLE
Refactor/home view

### DIFF
--- a/SnapPop/Application/AppDelegate.swift
+++ b/SnapPop/Application/AppDelegate.swift
@@ -19,11 +19,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Override point for customization after application launch.
         FirebaseApp.configure()
 
-        window = UIWindow(frame: UIScreen.main.bounds)
-        let rootViewController = CustomTabBarController()
-        let navigationController = UINavigationController(rootViewController: rootViewController)
-        window?.rootViewController = navigationController
-        window?.makeKeyAndVisible()
         return true
     }
     

--- a/SnapPop/FirebaseManager/CategoryService.swift
+++ b/SnapPop/FirebaseManager/CategoryService.swift
@@ -13,6 +13,9 @@ final class CategoryService {
     private let db = Firestore.firestore()
     private let storage = Storage.storage().reference()
     
+    private let snapService = SnapService()
+    private let managementService = ManagementService()
+    
     func saveCategory(category: Category, completion: @escaping (Result<Category, Error>) -> Void) {
         let documentRef = db.collection("Users")
             .document(AuthViewModel.shared.currentUser?.uid ?? "")
@@ -73,9 +76,9 @@ final class CategoryService {
         }
     }
     
-    func deleteCategory(categoryId: String, completion: @escaping (Error?) -> Void) {
+    func deleteCategory(userId: String, categoryId: String, completion: @escaping (Error?) -> Void) {
         db.collection("Users")
-            .document(AuthViewModel.shared.currentUser?.uid ?? "")
+            .document(userId)
             .collection("Categories")
             .document(categoryId)
             .delete { error in
@@ -85,5 +88,88 @@ final class CategoryService {
                     completion(nil)
                 }
             }
+    }
+    
+    // 카테고리 및 하위 데이터 삭제
+    func deleteCategoryWithAllData(userId: String, categoryId: String, completion: @escaping (Error?) -> Void) {
+        let group = DispatchGroup()
+
+        // 1. Managements 삭제
+        group.enter()
+        managementService.deleteManagements(userId: userId, categoryId: categoryId) { result in
+            switch result {
+            case .success:
+                print("Managements deleted successfully")
+                group.leave()
+            case .failure(let error):
+                print("Failed to delete Managements: \(error.localizedDescription)")
+                completion(error)
+                group.leave()
+                return
+            }
+        }
+
+        // 2. Snaps 삭제
+        group.enter()
+        snapService.deleteSnaps(userId: userId, categoryId: categoryId) { error in
+            if let error = error {
+                print("Failed to delete Snaps: \(error.localizedDescription)")
+                completion(error)
+                group.leave()
+                return
+            }
+            print("Snaps deleted successfully")
+            group.leave()
+        }
+
+        // 3. 모든 하위 데이터가 삭제된 후 카테고리 삭제
+        group.notify(queue: .main) {
+            self.deleteCategory(userId: userId, categoryId: categoryId) { error in
+                if let error = error {
+                    print("Failed to delete category: \(error.localizedDescription)")
+                    completion(error)
+                } else {
+                    print("Category deleted successfully")
+                    completion(nil)
+                }
+            }
+        }
+    }
+    
+    // 유저가 가진 카테고리들 모두 삭제
+    func deleteCategories(userId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        let documentRef = db.collection("Users")
+            .document(userId)
+            .collection("Categories")
+        
+        documentRef.getDocuments { (querySnapshot, error) in
+            if let error = error {
+                completion(.failure(error))
+                return
+            } else {
+                guard let documents = querySnapshot?.documents, !documents.isEmpty else {
+                    completion(.success(()))
+                    return
+                }
+                
+                let group = DispatchGroup()
+                
+                for document in documents {
+                    group.enter()
+                    self.deleteCategoryWithAllData(userId: userId, categoryId: document.documentID) { error in
+                        if let error = error {
+                            completion(.failure(error))
+                            group.leave()
+                            return
+                        }
+                        group.leave()
+                    }
+                }
+                
+                group.notify(queue: .main) {
+                    completion(.success(()))
+                }
+            }
+        }
     }
 }

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -124,9 +124,9 @@ final class SnapService {
             }
     }
     
-    func loadSnaps(categoryId: String, completion: @escaping (Result<[Snap], Error>) -> Void) {
+    func loadSnaps(userId: String, categoryId: String, completion: @escaping (Result<[Snap], Error>) -> Void) {
         db.collection("Users")
-            .document(AuthViewModel.shared.currentUser?.uid ?? "")
+            .document(userId)
             .collection("Categories")
             .document(categoryId)
             .collection("Snaps")
@@ -170,7 +170,8 @@ final class SnapService {
         }
     }
     
-    func deleteImage(categoryId: String, snap: Snap, imageUrlToDelete: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    // 회원 탈퇴 시 모든 데이터 삭제하는 부분에서 current user id 를 가져올수 없어 파라미터로 넣어서 전달하도록 수정
+    func deleteImage(userId: String, categoryId: String, snap: Snap, imageUrlToDelete: String, completion: @escaping (Result<Void, Error>) -> Void) {
         if let snapId = snap.id {
             var imageUrls = snap.imageUrls
             if let index = imageUrls.firstIndex(of: imageUrlToDelete) {
@@ -178,7 +179,7 @@ final class SnapService {
             }
             
             db.collection("Users")
-                .document(AuthViewModel.shared.currentUser?.uid ?? "")
+                .document(userId)
                 .collection("Categories")
                 .document(categoryId)
                 .collection("Snaps")
@@ -201,10 +202,10 @@ final class SnapService {
         }
     }
     
-    func deleteSnap(categoryId: String, snap: Snap, completion: @escaping (Error?) -> Void) {
+    func deleteSnap(userId: String, categoryId: String, snap: Snap, completion: @escaping (Error?) -> Void) {
         if let snapId = snap.id {
             db.collection("Users")
-                .document(AuthViewModel.shared.currentUser?.uid ?? "")
+                .document(userId)
                 .collection("Categories")
                 .document(categoryId)
                 .collection("Snaps")
@@ -217,9 +218,9 @@ final class SnapService {
         }
     }
     
-    func deleteSnaps(categoryId: String, completion: @escaping (Error?) -> Void) {
+    func deleteSnaps(userId: String, categoryId: String, completion: @escaping (Error?) -> Void) {
         
-        loadSnaps(categoryId: categoryId) { result in
+        loadSnaps(userId: userId, categoryId: categoryId) { result in
             switch result {
             case .success(let snaps):
                 
@@ -230,7 +231,7 @@ final class SnapService {
                 
                 for snap in snaps {
                     for imageUrl in snap.imageUrls {
-                        self.deleteImage(categoryId: categoryId, snap: snap, imageUrlToDelete: imageUrl) { result in
+                        self.deleteImage(userId: userId, categoryId: categoryId, snap: snap, imageUrlToDelete: imageUrl) { result in
                             switch result {
                             case .success():
                                 print("[SnapService] Success to deleteImage")
@@ -241,7 +242,7 @@ final class SnapService {
                     }
                     guard let snapId = snap.id else { return }
                     self.db.collection("Users")
-                        .document(AuthViewModel.shared.currentUser?.uid ?? "")
+                        .document(userId)
                         .collection("Categories")
                         .document(categoryId)
                         .collection("Snaps")

--- a/SnapPop/ViewModels/Home/HomeViewModel.swift
+++ b/SnapPop/ViewModels/Home/HomeViewModel.swift
@@ -258,7 +258,6 @@ class HomeViewModel: ObservableObject {
         }
     }
     
-    // MARK: - CategoryChangeDelegate
     func categoryDidChange(to newCategoryId: String?) {
         self.selectedCategoryId = newCategoryId
         

--- a/SnapPop/ViewModels/Root/CustomNavigationBarViewModel.swift
+++ b/SnapPop/ViewModels/Root/CustomNavigationBarViewModel.swift
@@ -38,6 +38,7 @@ class CustomNavigationBarViewModel: CustomNavigationBarViewModelProtocol {
     
     private let categoryService = CategoryService()
     private let snapService = SnapService()
+    private let managementService = ManagementService()
     
     // MARK: - Methods
     func loadCategories(completion: @escaping () -> Void) {
@@ -95,65 +96,73 @@ class CustomNavigationBarViewModel: CustomNavigationBarViewModelProtocol {
         let tempCategory = categories[index]
         categories.remove(at: index)
         
-        snapService.deleteSnaps(categoryId: categoryId) { error in
+        let userId = AuthViewModel.shared.currentUser?.uid ?? ""
+        snapService.deleteSnaps(userId: userId, categoryId: categoryId) { error in
             if let error = error {
                 print("[네비게이션바VM] Failed to deleteSnaps: \(error.localizedDescription)")
             } else {
-                self.categoryService.deleteCategory(categoryId: categoryId) { error in
-                    if let error = error {
-                        // TODO: - 카테고리는 다시 생기지만 Snaps는 삭제됨..
-                        print("Failed to delete category: \(error.localizedDescription)")
-                        self.categories.insert(tempCategory, at: index)
-                        self.categoryisUpdated?()
-                        completion(nil)
-                    } else {
-                        print("Successfully deleted category")
-                        // 현재 선택된 카테고리가 삭제된 카테고리인 경우
-                        if self.currentCategory?.id == categoryId {
-                            if self.categories.isEmpty {
-                                // 카테고리가 남아있지 않은 경우
-                                self.currentCategory = nil
-                                UserDefaults.standard.removeObject(forKey: "currentCategoryId")
-                                print("카테고리가 남아있지 않은 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
-//                                self.delegate?.categoryDidChange(to: nil)
-                                NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: nil)
-                                completion("카테고리를 추가해 주세요")
+                self.managementService.deleteManagements(userId: userId, categoryId: categoryId) { result in
+                    switch result {
+                    case .success:
+                        self.categoryService.deleteCategory(userId: userId, categoryId: categoryId) { error in
+                            if let error = error {
+                                // TODO: - 카테고리는 다시 생기지만 Snaps는 삭제됨..
+                                print("Failed to delete category: \(error.localizedDescription)")
+                                self.categories.insert(tempCategory, at: index)
+                                self.categoryisUpdated?()
+                                completion(nil)
                             } else {
-                                // 카테고리가 남아있는 경우 첫 번째 카테고리를 선택
-                                self.currentCategory = self.categories.first
-                                if let newCategoryId = self.currentCategory?.id {
-                                    UserDefaults.standard.set(newCategoryId, forKey: "currentCategoryId")
-//                                    self.delegate?.categoryDidChange(to: newCategoryId)
-                                    if let selectedCategory = self.currentCategory {
-                                        NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: ["categoryId": newCategoryId])
+                                print("Successfully deleted category")
+                                // 현재 선택된 카테고리가 삭제된 카테고리인 경우
+                                if self.currentCategory?.id == categoryId {
+                                    if self.categories.isEmpty {
+                                        // 카테고리가 남아있지 않은 경우
+                                        self.currentCategory = nil
+                                        UserDefaults.standard.removeObject(forKey: "currentCategoryId")
+                                        print("카테고리가 남아있지 않은 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
+        //                                self.delegate?.categoryDidChange(to: nil)
+                                        NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: nil)
+                                        completion("카테고리를 추가해 주세요")
+                                    } else {
+                                        // 카테고리가 남아있는 경우 첫 번째 카테고리를 선택
+                                        self.currentCategory = self.categories.first
+                                        if let newCategoryId = self.currentCategory?.id {
+                                            UserDefaults.standard.set(newCategoryId, forKey: "currentCategoryId")
+        //                                    self.delegate?.categoryDidChange(to: newCategoryId)
+                                            if let selectedCategory = self.currentCategory {
+                                                NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: ["categoryId": newCategoryId])
+                                            }
+                                            print("카테고리가 남아있는 경우 첫 번째 카테고리를 선택 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
+                                        }
+                                        completion(self.currentCategory?.title)
                                     }
-                                    print("카테고리가 남아있는 경우 첫 번째 카테고리를 선택 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
-                                }
-                                completion(self.currentCategory?.title)
-                            }
-                        } else {
-                            // 현재 선택된 카테고리가 삭제된 카테고리가 아닌 경우
-                            if let firstCategory = self.categories.first {
-                                self.currentCategory = firstCategory
-                                if let newCategoryId = firstCategory.id {
-                                    UserDefaults.standard.set(newCategoryId, forKey: "currentCategoryId")
-//                                    self.delegate?.categoryDidChange(to: newCategoryId)
-                                    if let selectedCategory = self.currentCategory {
-                                        NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: ["categoryId": newCategoryId])
+                                } else {
+                                    // 현재 선택된 카테고리가 삭제된 카테고리가 아닌 경우
+                                    if let firstCategory = self.categories.first {
+                                        self.currentCategory = firstCategory
+                                        if let newCategoryId = firstCategory.id {
+                                            UserDefaults.standard.set(newCategoryId, forKey: "currentCategoryId")
+        //                                    self.delegate?.categoryDidChange(to: newCategoryId)
+                                            if let selectedCategory = self.currentCategory {
+                                                NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: ["categoryId": newCategoryId])
+                                            }
+                                            print("현재 선택된 카테고리가 삭제된 카테고리가 아닌 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
+                                        }
+                                        completion(firstCategory.title)
+                                    } else {
+                                        // categories 배열이 비어있는 경우
+                                        self.currentCategory = nil
+                                        UserDefaults.standard.removeObject(forKey: "currentCategoryId")
+                                        print("categories 배열이 비어있는 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
+        //                                self.delegate?.categoryDidChange(to: nil)
+                                        NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: nil)
+                                        completion("카테고리를 추가해 주세요")
                                     }
-                                    print("현재 선택된 카테고리가 삭제된 카테고리가 아닌 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
                                 }
-                                completion(firstCategory.title)
-                            } else {
-                                // categories 배열이 비어있는 경우
-                                self.currentCategory = nil
-                                UserDefaults.standard.removeObject(forKey: "currentCategoryId")
-                                print("categories 배열이 비어있는 경우 삭제 후의 Current UserDefaults: \(String(describing: UserDefaults.standard.string(forKey: "currentCategoryId")))")
-//                                self.delegate?.categoryDidChange(to: nil)
-                                NotificationCenter.default.post(name: .categoryDidChange, object: nil, userInfo: nil)
-                                completion("카테고리를 추가해 주세요")
                             }
                         }
+                    case .failure(let error):
+                        print("[네비게이션바VM] Failed to deleteManagements: \(error.localizedDescription)")
                     }
                 }
             }

--- a/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
+++ b/SnapPop/ViewModels/SnapComparison/SnapComparisonViewModel.swift
@@ -275,7 +275,7 @@ class SnapComparisonViewModel: SnapComparisonViewModelProtocol {
     
     /// Firebase Snap Load Method
     func loadSanpstoFireStore(to categoryId: String) {
-        snapService.loadSnaps(categoryId: categoryId) { result in
+        snapService.loadSnaps(userId: AuthViewModel.shared.currentUser?.uid ?? "", categoryId: categoryId) { result in
             switch result {
             case .success(let snaps):
                 print("[FB] [Snap비교] 파이어베이스 스냅 로드")

--- a/SnapPop/Views/Home/ChecklistTableViewController.swift
+++ b/SnapPop/Views/Home/ChecklistTableViewController.swift
@@ -171,7 +171,7 @@ class ChecklistTableViewController: UITableViewController {
             let itemToDelete = viewModel.checklistItems[indexPath.row]
             
             // Firebase에서 항목 삭제
-            viewModel.deleteManagement(categoryId: viewModel.selectedCategoryId ?? "default", managementId: itemToDelete.id ?? "") { result in
+            viewModel.deleteManagement(userId: AuthViewModel.shared.currentUser?.uid ?? "", categoryId: viewModel.selectedCategoryId ?? "default", managementId: itemToDelete.id ?? "") { result in
                 DispatchQueue.main.async {
                     switch result {
                     case .success():

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -201,6 +201,7 @@ class HomeViewController:
         }
     }
     
+    // 스냅 업데이트 및 UI 리로드
     func updateSnapCollectionView() {
         DispatchQueue.main.async {
             self.snapCollectionView.reloadData() // UI 업데이트
@@ -217,17 +218,11 @@ class HomeViewController:
         // 카테고리 변경 시 snapCollectionView 리로드
         updateSnapCollectionView()
     }
-    // 스냅 업데이트 및 UI 리로드
-    @objc private func updateSnapCollectionView() {
-        DispatchQueue.main.async {
-            self.snapCollectionView.reloadData() // UI 업데이트
-        }
-    }
     
     private func updateUIWithCategories() {
-           // 카테고리 목록을 UI에 반영하는 로직을 추가합니다.
-           print("Loaded categories: \(navigationBarViewModel.categories)")
-       }
+        // 카테고리 목록을 UI에 반영하는 로직을 추가합니다.
+        print("Loaded categories: \(navigationBarViewModel.categories)")
+    }
     /// 날짜 선택 DatePicker UI 설정
     private func setupDatePickerView() {
         view.addSubview(datePickerContainer)

--- a/SnapPop/Views/Setting/SettingViewController.swift
+++ b/SnapPop/Views/Setting/SettingViewController.swift
@@ -13,6 +13,8 @@ import AuthenticationServices
 
 class SettingViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
+    private let authViewModel = AuthViewModel()
+    
     private lazy var settingTableView: UITableView = {
         let tableView = UITableView(frame: .zero, style: .insetGrouped)
         tableView.delegate = self
@@ -233,12 +235,18 @@ extension SettingViewController: ASAuthorizationControllerDelegate {
             return
         }
         
+        guard let user = AuthViewModel.shared.currentUser else {
+            print("No current user found")
+            return
+        }
+        
         Auth.auth().revokeToken(withAuthorizationCode: authCodeString)
-        AuthViewModel.shared.currentUser?.delete { error in
+        user.delete { error in
             if let error = error {
                 print("Error deleting user: \(error.localizedDescription)")
             } else {
                 print("Successfully deleted user")
+                self.authViewModel.deleteUserFromCollection(userId: user.uid)
             }
         }
     }


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 관리 삭제 시 하위 상세내역들도 삭제
- [x] 카테고리 삭제 시 하위 스냅, 관리들 삭제
- [x] 유저 탈퇴 시 유저 데이터 아래 카테고리 및 하위 데이터들 전부 삭제
- [x] 홈뷰 데이터 바인딩 코드 수정(컴바인 없이)
- [x] appdelegate에 불필요한 코드 삭제 

### 📸 스크린샷

### 🛠️ 작업 유형

- [x] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [x] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- SnapService의 delete함수에서 유저 탈퇴 시에는 AuthViewModel.shared.currentUser를 받아올수 없어, 직접 넣어주는 대신 파라미터로 받아오는 방식으로 수정하였어요
- 각 항목(유저, 카테고리, 관리)별로 삭제 시에 하위 데이터가 잘 삭제되는지 확인 부탁드려요

<br/><br/>