### PR TITLE
chore. 관리 삭제 시 테이블뷰 업데이트 되지 않는부분 수정 및 누락코드 추가

### DIFF
--- a/SnapPop/FirebaseManager/ManagementService.swift
+++ b/SnapPop/FirebaseManager/ManagementService.swift
@@ -110,6 +110,8 @@ final class ManagementService {
                     .delete { error in
                         if let error = error {
                             completion(error)
+                        } else {
+                            completion(nil)
                         }
                     }
             case .failure(let error):

--- a/SnapPop/FirebaseManager/SnapService.swift
+++ b/SnapPop/FirebaseManager/SnapService.swift
@@ -213,6 +213,8 @@ final class SnapService {
                 .delete { error in
                     if let error = error {
                         completion(error)
+                    } else {
+                        completion(nil)
                     }
                 }
         }

--- a/SnapPop/Views/Home/ChecklistTableViewController.swift
+++ b/SnapPop/Views/Home/ChecklistTableViewController.swift
@@ -40,8 +40,6 @@ class ChecklistTableViewController: UITableViewController {
         tableView.dataSource = self
         tableView.delegate = self
         
-        setupRefreshControl()
-        
         // 데이터 가져오기
         loadData()
 

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -474,28 +474,30 @@ class HomeViewController:
         let imageUrl = snap.imageUrls[index]
         
         viewModel.deleteImage(categoryId: categoryId, snap: snap, imageUrlToDelete: imageUrl) { result in
-            switch result {
-            case .success:
-                self.viewModel.snap?.imageUrls.remove(at: index) // 뷰모델의 snap객체에서 삭제할 사진 제거
-                
-                // 사진 아예 다 지워버리면 디비에서 스냅 자체를 삭제하고 nil로 초기화
-                if self.viewModel.snap?.imageUrls.isEmpty == true {
-                    self.viewModel.deleteSnap(categoryId: categoryId, snap: snap)
-                    self.viewModel.snap = nil
-                    self.updateSnapCollectionView()
-                }
-                
-                self.snapCollectionView.performBatchUpdates({
-                    self.snapCollectionView.deleteItems(at: [IndexPath(item: index, section: 0)]) // 컬렉션뷰에서 인덱스로 삭제
-                }) { _ in
-                    // 삭제 후 나머지 셀들이 있다면 태그 업데이트
-                    if self.viewModel.snap != nil {
-                        self.updateCellTags()
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    self.viewModel.snap?.imageUrls.remove(at: index) // 뷰모델의 snap객체에서 삭제할 사진 제거
+                    
+                    // 사진 아예 다 지워버리면 디비에서 스냅 자체를 삭제하고 nil로 초기화
+                    if self.viewModel.snap?.imageUrls.isEmpty == true {
+                        self.viewModel.deleteSnap(categoryId: categoryId, snap: snap)
+                        self.viewModel.snap = nil
+                        self.updateSnapCollectionView()
                     }
+                    
+                    self.snapCollectionView.performBatchUpdates({
+                        self.snapCollectionView.deleteItems(at: [IndexPath(item: index, section: 0)]) // 컬렉션뷰에서 인덱스로 삭제
+                    }) { _ in
+                        // 삭제 후 나머지 셀들이 있다면 태그 업데이트
+                        if self.viewModel.snap != nil {
+                            self.updateCellTags()
+                        }
+                    }
+                    print("사진 삭제 성공")
+                case .failure(let error):
+                    print("사진 삭제 실패: \(error.localizedDescription)")
                 }
-                print("사진 삭제 성공")
-            case .failure(let error):
-                print("사진 삭제 실패: \(error.localizedDescription)")
             }
         }
     }


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 관리목록에서 삭제시 목록 테이블뷰 바로 리로딩

### 📸 스크린샷

https://github.com/user-attachments/assets/92219270-d03f-46e0-9af1-a2e610e13c5d


### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [x] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- Refresh Control은 일단 ViewDidLoad에서 빼두었습니다

<br/><br/>