### PR TITLE
Feature/add management view

### DIFF
--- a/SnapPop/ViewModels/Home/HomeViewModel.swift
+++ b/SnapPop/ViewModels/Home/HomeViewModel.swift
@@ -28,7 +28,13 @@ class HomeViewModel: ObservableObject {
         }
     }
     @Published var snap: Snap?
-    @Published var selectedCategoryId: String?
+    @Published var selectedCategoryId: String? {
+        didSet {
+            fetchManagements(categoryId: selectedCategoryId ?? "default") { _ in
+                // 카테고리 아이디가 변경되었을 때 필요한 작업
+            }
+        }
+    }
     var selectedSource: ((UIImagePickerController.SourceType) -> Void)?
     var updateSnapCollectionView: (() -> Void)?
     
@@ -169,7 +175,6 @@ class HomeViewModel: ObservableObject {
                             NotificationManager.shared.removeNotification(identifiers: ["dailySnapNotification"])
                             NotificationManager.shared.scheduleDailySnapNotification(hour: hour)
                         }
-                        
                         
                         completion(.success(snap))
                     case .failure(let error):

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -26,7 +26,8 @@ class AddManagementViewModel {
     var management: Management
     var detailCostArray: [DetailCost] = [] // 추가한 상세 비용들을 담을 배열
     private let db = ManagementService()
-    
+    private let categoryService = CategoryService()
+
     let repeatOptions = ["매일", "매주", "안함"]
     
     init(categoryId: String?, management: Management) {
@@ -115,6 +116,19 @@ class AddManagementViewModel {
             .store(in: &cancellables)
     }
     
+    func loadCategories(completion: @escaping (Result<[Category], Error>) -> Void) {
+        categoryService.loadCategories { result in
+            switch result {
+            case .success(let categories):
+                print("카테고리를 성공적으로 불러왔습니다: \(categories)")
+                completion(.success(categories))
+            case .failure(let error):
+                print("카테고리 불러오기 실패: \(error.localizedDescription)")
+                completion(.failure(error))
+            }
+        }
+    }
+    
     func updateRepeatCycle(_ cycleIndex: Int) {
         self.repeatCycle = cycleIndex
         
@@ -139,16 +153,39 @@ class AddManagementViewModel {
     }
     
     func saveOrUpdate(completion: @escaping (Result<Void, Error>) -> Void) {
-        if edit {
-            // 편집 모드 - 관리 항목 업데이트
-            guard let categoryId = categoryId, let managementId = management.id else {
-                completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "카테고리 ID 또는 관리 항목 ID가 필요합니다."])))
-                return
+        guard let categoryId = self.categoryId else {
+            completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "카테고리 ID가 필요합니다."])))
+            return
+        }
+
+        checkCategoryNotificationStatus(categoryId: categoryId) { isCategoryNotificationEnabled in
+            if self.edit {
+                // 편집 모드 - 관리 항목 업데이트
+                guard let managementId = self.management.id else {
+                    completion(.failure(NSError(domain: "", code: -1, userInfo: [NSLocalizedDescriptionKey: "관리 항목 ID가 필요합니다."])))
+                    return
+                }
+                self.db.updateManagement(categoryId: categoryId, managementId: managementId, updatedManagement: self.management) { result in
+                    if case .success = result {
+                        // 카테고리와 관리 항목의 알림 상태가 모두 true일 때만 알림을 추가
+                        if isCategoryNotificationEnabled && self.management.alertStatus {
+                            self.addNotification(for: self.management)
+                        }
+                    }
+                    completion(result)
+                }
+            } else {
+                // 추가 모드 - 새로운 관리 항목 저장
+                self.save { result in
+                    if case .success = result {
+                        // 카테고리와 관리 항목의 알림 상태가 모두 true일 때만 알림을 추가
+                        if isCategoryNotificationEnabled && self.management.alertStatus {
+                            self.addNotification(for: self.management)
+                        }
+                    }
+                    completion(result)
+                }
             }
-            db.updateManagement(categoryId: categoryId, managementId: managementId, updatedManagement: management, completion: completion)
-        } else {
-            // 추가 모드 - 새로운 관리 항목 저장(맞네이렇게해야되네)
-            save(completion: completion)
         }
     }
     
@@ -231,6 +268,58 @@ class AddManagementViewModel {
             case .failure(let error):
                 print("Failed to save management: \(error.localizedDescription)")
                 completion(.failure(error))
+            }
+        }
+    }
+    
+    // 카테고리 알림 상태 확인 메서드 추가
+    private func checkCategoryNotificationStatus(categoryId: String, completion: @escaping (Bool) -> Void) {
+        categoryService.loadCategories { result in
+            switch result {
+            case .success(let categories):
+                // 특정 categoryId를 가진 카테고리 검색
+                if let category = categories.first(where: { $0.id == categoryId }) {
+                    completion(category.alertStatus)
+                } else {
+                    print("카테고리를 찾을 수 없습니다.")
+                    completion(false)
+                }
+            case .failure(let error):
+                print("카테고리 로드 실패: \(error.localizedDescription)")
+                completion(false)
+            }
+        }
+    }
+
+    // 알림 추가 메서드 추가
+    private func addNotification(for management: Management) {
+        guard let categoryId = self.categoryId, let managementId = management.id else { return }
+        
+        if management.repeatCycle == 0 {
+            // 한 번만 알림 추가
+            NotificationManager.shared.initialNotification(categoryId: categoryId,
+                                                           managementId: managementId,
+                                                           startDate: management.startDate,
+                                                           alertTime: management.alertTime,
+                                                           repeatCycle: management.repeatCycle,
+                                                           body: management.title)
+        } else {
+            if isSpecificDateInPast(startDate: self.startDate, alertTime: self.alertTime) {
+                // 과거 날짜에 대한 반복 알림 추가
+                NotificationManager.shared.repeatingNotification(categoryId: categoryId,
+                                                                 managementId: managementId,
+                                                                 startDate: management.startDate,
+                                                                 alertTime: management.alertTime,
+                                                                 repeatCycle: management.repeatCycle,
+                                                                 body: management.title)
+            } else {
+                // 반복 알림을 트리거할 초기 알림 추가
+                NotificationManager.shared.initialNotification(categoryId: categoryId,
+                                                               managementId: managementId,
+                                                               startDate: management.startDate,
+                                                               alertTime: management.alertTime,
+                                                               repeatCycle: management.repeatCycle,
+                                                               body: management.title)
             }
         }
     }

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -307,7 +307,6 @@ extension UIColor {
     }
 }
 
-
 extension Notification.Name {
     static let categoryDidChangeNotification = Notification.Name("categoryDidChangeNotification")
     static let managementSavedNotification = Notification.Name("managementSavedNotification")

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -4,7 +4,6 @@
 //
 //  Created by 장예진 on 8/9/24.
 //
-
 import Combine
 import UIKit
 import FirebaseFirestore
@@ -158,6 +157,7 @@ class AddManagementViewModel {
             return
         }
 
+        // 카테고리의 알림 상태 확인
         checkCategoryNotificationStatus(categoryId: categoryId) { isCategoryNotificationEnabled in
             if self.edit {
                 // 편집 모드 - 관리 항목 업데이트
@@ -170,6 +170,9 @@ class AddManagementViewModel {
                         // 카테고리와 관리 항목의 알림 상태가 모두 true일 때만 알림을 추가
                         if isCategoryNotificationEnabled && self.management.alertStatus {
                             self.addNotification(for: self.management)
+                        } else {
+                            // 알림 상태가 false이거나 카테고리 알림이 꺼져 있으면 기존 알림 취소
+                            self.cancelNotification(for: self.management)
                         }
                     }
                     completion(result)
@@ -181,6 +184,9 @@ class AddManagementViewModel {
                         // 카테고리와 관리 항목의 알림 상태가 모두 true일 때만 알림을 추가
                         if isCategoryNotificationEnabled && self.management.alertStatus {
                             self.addNotification(for: self.management)
+                        } else {
+                            // 알림 상태가 false이거나 카테고리 알림이 꺼져 있으면 기존 알림 취소
+                            self.cancelNotification(for: self.management)
                         }
                     }
                     completion(result)
@@ -188,6 +194,7 @@ class AddManagementViewModel {
             }
         }
     }
+
     
     // 유효성 검증 프로퍼티
     var isValid: AnyPublisher<Bool, Never> {
@@ -262,6 +269,9 @@ class AddManagementViewModel {
                                                                            body: management.title)
                         }
                     }
+                } else {
+                    // 알림 상태가 false일 때 기존 알림 취소
+                    self.cancelNotification(for: management)
                 }
                 
                 completion(.success(()))
@@ -270,6 +280,15 @@ class AddManagementViewModel {
                 completion(.failure(error))
             }
         }
+    }
+       
+    private func cancelNotification(for management: Management) {
+        guard let categoryId = self.categoryId, let managementId = management.id else { return }
+        let identifiers = [
+            "initialNotification-\(categoryId)-\(managementId)",
+            "repeatingNotification-\(categoryId)-\(managementId)"
+        ]
+        NotificationManager.shared.removeNotification(identifiers: identifiers)
     }
     
     // 카테고리 알림 상태 확인 메서드 추가

--- a/SnapPop/Views/Home/ChecklistTableViewController.swift
+++ b/SnapPop/Views/Home/ChecklistTableViewController.swift
@@ -13,8 +13,6 @@ class ChecklistTableViewController: UITableViewController {
     var viewModel: HomeViewModel?
     private var cancellables = Set<AnyCancellable>() // Combine 구독을 저장할 Set
     private let managementService = ManagementService() // ManagementService 인스턴스 추가
-
-//    private let refreshControl = UIRefreshControl()
     
     // 관리 항목 추가 버튼
     private let selfcareAddButton: UIButton = {
@@ -27,7 +25,13 @@ class ChecklistTableViewController: UITableViewController {
         button.addTarget(self, action: #selector(didSelfcareAddButton), for: .touchUpInside)
         return button
     }()
-    
+    // 로딩 있을 때를 대비한 loading indicator (필요시)
+//    private let loadingIndicator: UIActivityIndicatorView = {
+//        let indicator = UIActivityIndicatorView(style: .large)
+//        indicator.translatesAutoresizingMaskIntoConstraints = false
+//        return indicator
+//    }()
+
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubview(selfcareAddButton)
@@ -47,11 +51,22 @@ class ChecklistTableViewController: UITableViewController {
         viewModel?.$checklistItems
              .receive(on: RunLoop.main)
              .sink { [weak self] _ in
-                 self?.tableView.reloadData()
+//                 self?.tableView.reloadData()
+//                 self?.startLoading()
+                 self?.loadData()
+
              }
              .store(in: &cancellables)
      }
-    
+//    // 카테고리 변경 시 로딩 indicator
+//    private func startLoading() {
+//        loadingIndicator.startAnimating()
+//    }
+//
+//    private func stopLoading() {
+//        loadingIndicator.stopAnimating()
+//    }
+
     private func setupButtonConstraints() {
         NSLayoutConstraint.activate([
             selfcareAddButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
@@ -60,22 +75,6 @@ class ChecklistTableViewController: UITableViewController {
             selfcareAddButton.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.8)
         ])
     }
-    
-    private func setupRefreshControl() {
-        refreshControl = UIRefreshControl()
-//        refreshControl?.attributedTitle = NSAttributedString(string: "당겨서 새로고침")
-        refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
-        tableView.refreshControl = refreshControl
-    }
-
-
-    @objc private func refreshData() {
-        loadData()
-        DispatchQueue.main.async {
-            self.refreshControl?.endRefreshing()
-        }
-    }
-
 
     private func loadData() {
         guard let viewModel = viewModel else { return }

--- a/SnapPop/Views/Home/ChecklistTableViewController.swift
+++ b/SnapPop/Views/Home/ChecklistTableViewController.swift
@@ -215,7 +215,15 @@ class ChecklistTableViewController: UITableViewController {
                     case .success():
                         // 삭제가 성공한 경우 UI 업데이트
                         viewModel.checklistItems.remove(at: indexPath.row)
-                        tableView.deleteRows(at: [indexPath], with: .automatic)
+                        
+                        if viewModel.checklistItems.isEmpty {
+                            // 모든 항목이 삭제된 경우 전체 섹션을 다시 로드하여 빈 상태를 보여줍니다.
+                            tableView.reloadSections(IndexSet(integer: 0), with: .automatic)
+                        } else {
+                            // 항목이 남아 있는 경우 해당 행만 삭제합니다.
+                            tableView.deleteRows(at: [indexPath], with: .automatic)
+                        }
+                        
                         completionHandler(true)
                     case .failure(let error):
                         // 삭제가 실패한 경우 사용자에게 알림
@@ -273,6 +281,7 @@ class ChecklistTableViewController: UITableViewController {
         
         return configuration
     }
+
 
 
     // 왼쪽으로 스와이프할 때 핀 고정 액션 추가

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -407,9 +407,9 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                     self?.viewModel.startDate = newDate
                     print("ViewModel startDate updated to: \(newDate)")
                 }
-//                cell.dismissHandler = { [weak self] in
-//                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
-//                }
+                cell.dismissHandler = { [weak self] in
+                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
+                }
                 return cell
             case 1:
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "RepeatCell", for: indexPath) as? RepeatCell else { return UITableViewCell() }

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -67,7 +67,12 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
 
         print(UserDefaults.standard.dictionaryRepresentation())
         viewModel.categoryDidChange(to: UserDefaults.standard.string(forKey: "currentCategoryId") ?? "default")
-//        bindViewModel() // ViewModel 바인딩(combine)
+        // 네비게이션 타이틀 설정
+        if viewModel.edit {
+            title = "관리 수정"
+        } else {
+            title = "새로운 자기 관리"
+        }
     }
     
     // NotificationCenter에서 사용할 메서드

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -403,9 +403,13 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                     return UITableViewCell()
                 }
                 cell.configure(with: viewModel.startDate)
-                cell.dismissHandler = { [weak self] in
-                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
+                cell.dateChangedHandler = { [weak self] newDate in
+                    self?.viewModel.startDate = newDate
+                    print("ViewModel startDate updated to: \(newDate)")
                 }
+//                cell.dismissHandler = { [weak self] in
+//                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
+//                }
                 return cell
             case 1:
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "RepeatCell", for: indexPath) as? RepeatCell else { return UITableViewCell() }

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -339,38 +339,6 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
             return nil
         }
     }
-    // 상세내역 아무것도 없을떄
-    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        if section == 3 && viewModel.detailCostArray.isEmpty {
-            let footerView = UIView()
-            let label = UILabel()
-            label.text = "아래의 버튼을 눌러 상세 내역을 추가해보세요!"
-            label.textAlignment = .center
-            label.textColor = .gray
-            label.font = UIFont.systemFont(ofSize: 14)
-            label.translatesAutoresizingMaskIntoConstraints = false
-
-            footerView.addSubview(label)
-
-            NSLayoutConstraint.activate([
-                label.centerXAnchor.constraint(equalTo: footerView.centerXAnchor),
-                label.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
-                label.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: 16),
-                label.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -16)
-            ])
-
-            return footerView
-        }
-        return nil
-    }
-
-    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        if section == 3 && viewModel.detailCostArray.isEmpty {
-            return 50 // Footer 높이 설정
-        }
-        return 0
-    }
-
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         switch indexPath.section {

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -53,6 +53,9 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
         bindViewModel()
         setupTapGesture()
         
+        // 알림 다시 꺼도 앱 안터지게
+        isTimePickerVisible = viewModel.alertStatus
+
         // NotificationCenter를 사용하게 변경
         NotificationCenter.default.addObserver(self, selector: #selector(categoryDidChangeNotification(_:)), name: .categoryDidChangeNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(managementSavedNotification(_:)), name: .managementSavedNotification, object: nil)
@@ -191,19 +194,23 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
     // NotificationCellDelegate 메서드 - 알림 스위치 토글 시 호출
     func notificationCellDidToggle(_ cell: NotificationCell, isOn: Bool) {
         viewModel.alertStatus = isOn
-        isTimePickerVisible = isOn
+        let indexPath = IndexPath(row: 1, section: 2) // 타임 피커 행의 IndexPath
+        tableView.beginUpdates()
         
-        // 알림 스위치 상태에 따라 테이블뷰 업데이트
-        UIView.animate(withDuration: 0.3) {
-            self.tableView.beginUpdates()
-            if isOn {
-                self.tableView.insertRows(at: [IndexPath(row: 1, section: 2)], with: .fade)
-            } else {
-                self.tableView.deleteRows(at: [IndexPath(row: 1, section: 2)], with: .fade)
+        if isOn {
+            if !isTimePickerVisible {
+                isTimePickerVisible = true
+                tableView.insertRows(at: [indexPath], with: .fade)
             }
-            self.tableView.endUpdates()
+        } else {
+            if isTimePickerVisible {
+                isTimePickerVisible = false
+                tableView.deleteRows(at: [indexPath], with: .fade)
+            }
         }
         
+        tableView.endUpdates()
+
         if isOn {
             viewModel.alertTime = Date()
         }

--- a/SnapPop/Views/Management/CustomAddTableViewCell.swift
+++ b/SnapPop/Views/Management/CustomAddTableViewCell.swift
@@ -128,6 +128,7 @@ class ColorCell: BaseTableViewCell {
 // -MARK: 날짜
 class DateCell: BaseTableViewCell {
     var dismissHandler: (() -> Void)?
+    var dateChangedHandler: ((Date) -> Void)?
     
     private let datePicker: UIDatePicker = {
         let datePicker = UIDatePicker()
@@ -159,10 +160,11 @@ class DateCell: BaseTableViewCell {
     }
     
     @objc private func datePickerValueChanged(_ sender: UIDatePicker) {
+        print("Date changed to: \(sender.date)")
+        dateChangedHandler?(sender.date)
         dismissHandler?()
     }
 }
-
 // -MARK: 반복
 class RepeatCell: BaseTableViewCell {
     let repeatButton: UIButton = {


### PR DESCRIPTION
### ✨ 작업 내역

- [x] - 카테고리 알림 상태 true/false체크 해서 true일 때 알림 추가 하도록 수정
- [x] - 예전,이후 (오늘기준) 날짜 불러오면 저장 잘 안되던 문제 수정
- [x] - 관리목록 없을때 멘트 추가 
- [x] - 관리 등록할때 알림 설정하고 편집할때 다시 알림 끄면 앱 터지는 문제 수정 
- [x] - 마지막 관리목록 삭제하면 앱 터지는 문제 수정
- [x] - 카테고리 별로 관리목록 필터링 

### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [ ] PR과 관련없는 변경사항은 없나요?
- [ ] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- 특이 사항 1
-(하는중) 
// -TODO: 홈뷰에서 관리 목록 편집 누르면 상세내역 로드 안되는 문제 해결  
// -TODO: 홈뷰에서 날짜 선택 시 관리 목록 반복에 맞게 필터링
// -TODO:  alertTIme이 startdate에 따라서 업데이트되어야함
// - TODO: 반복 수정하면 completions도 바뀌어야함  

(수정완료)
~카테고리 별로 관리목록 필터링 (refresh control있으면 바로바로 카테고리 바뀐거 볼수있긴했는데 지금은 일단 바로 안됨)수정해야할듯~
<br/><br/>