### PR TITLE
refactor: 필터링 로직 수정

### DIFF
--- a/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
+++ b/SnapPop/Views/SnapComparison/SnapComparisonViewController.swift
@@ -207,12 +207,27 @@ class SnapComparisonViewController: UIViewController {
         if viewModel.snapDateMenuItems.isEmpty {
             selectSnapDateButton.isEnabled = false
             selectSnapDateButton.setTitle("날짜 없음", for: .normal)
+            selectSnapDateButton.menu = nil
         } else {
-            let selectDateMenu = UIMenu(title: "날짜 선택", children: viewModel.snapDateMenuItems)
+            let selectDateMenu = UIMenu(title: "날짜 선택", children: viewModel.snapDateMenuItems.map { action in
+                UIAction(title: action.title, handler: { [weak self] _ in
+                    if let date = self?.titleToDateString(action.title) {
+                        self?.viewModel.changeSnapDate(date: date) {
+                            self?.reloadCollectionView()
+                        }
+                    }
+                })
+            })
             selectSnapDateButton.menu = selectDateMenu
             selectSnapDateButton.showsMenuAsPrimaryAction = true
             selectSnapDateButton.isEnabled = true
         }
+    }
+    
+    private func titleToDateString(_ title: String) -> Date? {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy년 MM월 d일"
+        return formatter.date(from: title)
     }
     
     func setupBindings() {
@@ -249,6 +264,11 @@ class SnapComparisonViewController: UIViewController {
             self.snapAndCategoryCheckLabel.isHidden = true
             self.snapAndCategoryCheckLabel.text = ""
             self.selectSnapDateButton.isEnabled = true
+        }
+        viewModel.updateMenu = { [weak self] in
+            DispatchQueue.main.async {
+                self?.setupMenu()
+            }
         }
     }
     


### PR DESCRIPTION
- 선택된 날짜로부터 오래된 스냅 사진 정렬
- 기준 스냅 버튼 메뉴 카테고리 변경시에 메뉴가 초기화되지 않는 현상 해결

### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 선택된 날짜로부터 오래된 스냅 사진 정렬

### 📸 스크린샷

https://github.com/user-attachments/assets/bde82346-28ad-4a92-a3de-a97e8ca60d63


### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [x] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [ ] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- 아놔 필터링 진촤 화가나ㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏㅏ

<br/><br/>