### PR TITLE
Refactor/modify management

### DIFF
--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -81,20 +81,7 @@ class AddManagementViewModel {
         
         $startDate
             .sink { [weak self] newValue in
-                guard let self = self else { return }
-                
-                let startDate = self.management.startDate // 수정전 날짜 담아둘 변수
-                self.management.startDate = newValue
-                
-                if self.edit {
-                    let calendar = Calendar.current
-                    let startDateComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
-                    let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
-                    
-                    if startDateComponents != newDateComponents {
-                        self.updateCompletions()
-                    }
-                }
+                self?.management.startDate = newValue
             }
             .store(in: &cancellables)
         
@@ -137,7 +124,7 @@ class AddManagementViewModel {
         }
     }
     
-    private func updateCompletions() {
+    func updateCompletions() {
         // 초기화
         self.management.completions.removeAll()
         // 새로운 completions 값 생성

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -23,6 +23,7 @@ class AddManagementViewModel {
     @Published var detailCostArray: [DetailCost] = [] // 추가한 상세 내역들을 담을 배열
     
     var edit = false // 편집
+    var updateStartDate: Bool = false
     private var cancellables = Set<AnyCancellable>()
     var management: Management
     private let db = ManagementService()
@@ -92,6 +93,7 @@ class AddManagementViewModel {
                     let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
                     
                     if startDateComponents != newDateComponents {
+                        self.updateStartDate = true
                         self.updateCompletions()
                     }
                 }

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -23,7 +23,6 @@ class AddManagementViewModel {
     @Published var detailCostArray: [DetailCost] = [] // 추가한 상세 내역들을 담을 배열
     
     var edit = false // 편집
-    var updateStartDate: Bool = false
     private var cancellables = Set<AnyCancellable>()
     var management: Management
     private let db = ManagementService()
@@ -93,7 +92,6 @@ class AddManagementViewModel {
                     let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
                     
                     if startDateComponents != newDateComponents {
-                        self.updateStartDate = true
                         self.updateCompletions()
                     }
                 }
@@ -217,7 +215,6 @@ class AddManagementViewModel {
         }
     }
 
-    
     // 유효성 검증 프로퍼티
     var isValid: AnyPublisher<Bool, Never> {
         return Publishers.CombineLatest3($title, $color, $startDate)

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -104,7 +104,7 @@ class AddManagementViewModel {
                 guard let self = self else { return }
                 self.management.repeatCycle = newValue
                 if self.edit {
-                    self.updateCompletions()
+                    self.updateCompletionsWhenRepeatCycleChanged()
                 }
             }
             .store(in: &cancellables)
@@ -142,6 +142,18 @@ class AddManagementViewModel {
         self.management.completions.removeAll()
         // 새로운 completions 값 생성
         self.management.completions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
+    }
+    
+    private func updateCompletionsWhenRepeatCycleChanged() {
+        var newCompletions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
+        
+        for (key, value) in self.management.completions {
+            if newCompletions.keys.contains(key) {
+                newCompletions[key] = value
+            }
+        }
+        
+        self.management.completions = newCompletions
     }
     
     func categoryDidChange(to newCategoryId: String?) {

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -82,9 +82,18 @@ class AddManagementViewModel {
         $startDate
             .sink { [weak self] newValue in
                 guard let self = self else { return }
+                
+                let startDate = self.management.startDate // 수정전 날짜 담아둘 변수
                 self.management.startDate = newValue
+                
                 if self.edit {
-                    self.updateCompletions()
+                    let calendar = Calendar.current
+                    let startDateComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
+                    let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
+                    
+                    if startDateComponents != newDateComponents {
+                        self.updateCompletions()
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -52,7 +52,10 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
         setupUI()
         bindViewModel()
         setupTapGesture()
-        viewModel.startDate = self.selectedDate
+        
+        if !viewModel.edit {
+            viewModel.startDate = self.selectedDate // 수정시에 management.startDate를 selectedDate가 업데이트해버려서 처음 등록시에만 실행되게 변경
+        }
         // 알림 다시 꺼도 앱 안터지게
         isTimePickerVisible = viewModel.alertStatus
 

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -442,6 +442,7 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                         let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
                         
                         let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                            self.viewModel.updateCompletions()
                             self.presentedViewController?.dismiss(animated: false, completion: nil)
                         }
                         let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -151,6 +151,24 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
     
     // MARK: - Actions    
     @objc private func saveButtonTapped() {
+        if viewModel.updateStartDate {
+            let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
+            
+            let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                self.saveManagement()
+            }
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+            
+            alert.addAction(changeAction)
+            alert.addAction(cancelAction)
+            
+            present(alert, animated: true, completion: nil)
+        } else {
+            saveManagement()
+        }
+    }
+    
+    private func saveManagement() {
         viewModel.saveOrUpdate { [weak self] result in
             switch result {
             case .success:
@@ -165,7 +183,6 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
             }
         }
     }
-
     
     @objc private func titleChanged(_ sender: UITextField) {
         // 타이틀 텍스트 필드 값 변경 시 ViewModel에 반영

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -151,24 +151,6 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
     
     // MARK: - Actions    
     @objc private func saveButtonTapped() {
-        if viewModel.updateStartDate {
-            let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
-            
-            let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
-                self.saveManagement()
-            }
-            let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-            
-            alert.addAction(changeAction)
-            alert.addAction(cancelAction)
-            
-            present(alert, animated: true, completion: nil)
-        } else {
-            saveManagement()
-        }
-    }
-    
-    private func saveManagement() {
         viewModel.saveOrUpdate { [weak self] result in
             switch result {
             case .success:
@@ -448,13 +430,31 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "DateCell", for: indexPath) as? DateCell else {
                     return UITableViewCell()
                 }
+                
                 cell.configure(with: viewModel.startDate)
                 cell.dateChangedHandler = { [weak self] newDate in
-                    self?.viewModel.startDate = newDate
+                    guard let self = self else { return }
+                    
+                    let previousDate = self.viewModel.startDate
+                    self.viewModel.startDate = newDate
+                    
+                    if self.viewModel.edit {
+                        let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
+                        
+                        let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                            self.presentedViewController?.dismiss(animated: false, completion: nil)
+                        }
+                        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+                            self.viewModel.startDate = previousDate // 취소시 변경전 날짜로 되돌림
+                            self.presentedViewController?.dismiss(animated: false, completion: nil)
+                        }
+                        
+                        alert.addAction(changeAction)
+                        alert.addAction(cancelAction)
+                        
+                        self.presentedViewController?.present(alert, animated: true, completion: nil)
+                    }
                     print("ViewModel startDate updated to: \(newDate)")
-                }
-                cell.dismissHandler = { [weak self] in
-                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
                 }
                 return cell
             case 1:


### PR DESCRIPTION
### ✨ 작업 내역

> 구현 내용 및 작업한 내역을 작성해주세요

- [x] 관리수정 시 completions 배열이 초기화되지 않도록 수정
- [x] 관리수정 시 날짜에 오늘 날짜가 아닌 관리 시작 날짜를 가져오도록 수정
- [x] 날짜 변경 없이 반복주기만 수정 시 completions에서 체크해놓은 데이터 유지
- [x] datepicker로 날짜 변경 시 alert 추가  

### 📸 스크린샷

https://github.com/user-attachments/assets/02b2f6d1-627b-4f76-b9e0-424da849a868

<img width="300" alt="스크린샷 2024-08-31 오전 1 48 28" src="https://github.com/user-attachments/assets/0c30c05a-e855-47e1-b43c-102fbc57c2b7">


### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [x] 버그 수정
- [ ] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [x] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> PR을 리뷰할 때 중점적으로 봐야 하거나, 언급하고 싶은 내용이 있다면 적어주세요

- 관리수정 시 날짜가 변경되면 completions은 초기화되도록 했어요. 더 괜찮은 방법이 있으면 알려주세요~

<br/><br/>