### PR TITLE
Refactor. 스냅비교뷰 스냅 비교 필터링 로직 수정.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,5 +75,10 @@
 - 기간을 설정하고 나의 변화를 한 눈에 확인하세요
 - 원하는 날짜나 스냅을 필터링 해서 볼 수 있어요
 
+
+## 🎬 시연
+
+[![Watch the video](https://img.youtube.com/vi/0u_8kLCgKnY/mqdefault.jpg)](https://www.youtube.com/watch?v=0u_8kLCgKnY)
+
 ---------
 ##### © 2024 Challengers. This project was developed by the Challengers team for the APP-iOS5th final project.

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 
 ## 📁 자료
 
-- [발표 자료](https://docs.google.com/presentation/d/-1RDBDWfrlNI0skLYHRhqs08he_VY/edit?usp=sharing)  
+- [발표 자료](https://drive.google.com/file/d/1kw7M6ju4VNDoLfRP0voEcrGV1MkkcfSk/view?usp=drive_link) 
 - [시연 영상](https://www.youtube.com/watch?v=Np8dwwVDayQ)
 
 ---------

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
 #  FinalProject - SnapPop
+팀 챌린저스 최종 프로젝트
 
-## Overview 
+## 🔍 프로젝트 소개 
 
 1. 매일 나의 상태를 기록하고, 모아서 비교하자!
 2. 사용하는 화장품, 복용하는 약, 먹는 영양제 등 매일 사용하는 제품의 비용과 효과를 한 눈에 확인해보세요.
 3. 알림설정을 통해 잊지 않고 자기관리를 할 수 있습니다.
 
-<br>
-
-## Team: Challengers (챌린저스) 
+## 👥 팀원
 
 <div align="center">
 
@@ -18,25 +17,63 @@
 
 </div>
 
-
-<br>
-
-## 1. Period
+## ⏳ 프로젝트 기간
 
 - 2024-07-29 ~ 2024-09-13
 
-## 2. IDE 
+## 🛠️ 기술스택 & 개발툴
+<img src="https://img.shields.io/badge/swift-F05138?style=for-the-badge&logo=swift&logoColor=white"><img src="https://img.shields.io/badge/xcode-147EFB?style=for-the-badge&logo=xcode&logoColor=white"><img src="https://img.shields.io/badge/discord-5865F2?style=for-the-badge&logo=discord&logoColor=white"><img src="https://img.shields.io/badge/github-181717?style=for-the-badge&logo=github&logoColor=white"><img src="https://img.shields.io/badge/Notion-000000?style=for-the-badge&logo=notion&logoColor=black"><img src="https://img.shields.io/badge/figma-F24E1E?style=for-the-badge&logo=figma&logoColor=white"><img src="https://img.shields.io/badge/firebase-FFCA28?style=for-the-badge&logo=firebase&logoColor=white">
 
-- Xcode
+#### 개발환경
+- Swift 5.10
+- Xcode 15.4
+- iOS 17.0
 
-## 3. Tech Stack
-
+#### 기술스택
 - UIKit
-- SwiftUI 
-- EventKit 
+- Firebase
+  - Authentication: 사용자 인증
+  - Firestore: 사용자 데이터 저장
+  - Storage: 업로드한 이미지 파일 저장
+- KingFisher, SwiftLint, DGCharts
 
-<br> 
+#### 협업툴
+- Discord, Github, Notion
+- Figma
 
+
+## ✨ 기능
+<table align="center">
+  <tr>
+    <th><code>홈</code></th>
+    <th><code>달력</code></th>
+    <th><code>통계 차트</code></th>
+    <th><code>스냅 비교</code></th>
+  </tr>
+  <tr>
+    <td><img src="https://github.com/user-attachments/assets/055633a0-dcb3-48f4-89ce-b554fa8bbe67" alt="홈"></td>
+    <td><img src="https://github.com/user-attachments/assets/9048d520-4965-433d-aeb8-93f3cf9e52de" alt="달력"></td>
+    <td><img src="https://github.com/user-attachments/assets/0508a0a4-53ac-4f0a-8b08-89c6fee613bf" alt="통계 차트"></td>
+    <td><img src="https://github.com/user-attachments/assets/cc8c0454-fc2c-4381-b5b2-3faf4d4e2372" alt="스냅 비교"></td>
+  </tr>
+</table>
+<br>
+
+#### 홈
+- 오늘의 모습을 사진으로 간편하게 기록해요. 사진은 안전하게 보호됩니다
+- 나만의 관리를 등록하고 꾸준히 체크합니다. 반복과 알림설정으로 루틴을 놓치지 마세요
+
+#### 달력
+- 스냅을 올리면 날마다 팝콘 도장을 획득할 수 있습니다
+- 관리를 모두 완료하고 황금 팝콘을 채워보세요
+
+#### 통계 차트
+- 등록한 자기 관리의 월 별 달성률을 나타냅니다
+- 각 관리 항목에 소요되는 비용을 추가하면, 비용 통계를 제공합니다
+
+#### 스냅 비교
+- 기간을 설정하고 나의 변화를 한 눈에 확인하세요
+- 원하는 날짜나 스냅을 필터링 해서 볼 수 있어요
 
 ---------
 ##### © 2024 Challengers. This project was developed by the Challengers team for the APP-iOS5th final project.

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@
 - 원하는 날짜나 스냅을 필터링 해서 볼 수 있어요
 
 
-## 🎬 시연
+## 📁 자료
 
-[![Watch the video](https://img.youtube.com/vi/Np8dwwVDayQ/mqdefault.jpg)](https://www.youtube.com/watch?v=Np8dwwVDayQ)
+- [발표 자료](https://docs.google.com/presentation/d/-1RDBDWfrlNI0skLYHRhqs08he_VY/edit?usp=sharing)  
+- [시연 영상](https://www.youtube.com/watch?v=Np8dwwVDayQ)
 
 ---------
 ##### © 2024 Challengers. This project was developed by the Challengers team for the APP-iOS5th final project.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 
 ## 📁 자료
 
-- [발표 자료](https://drive.google.com/file/d/1kw7M6ju4VNDoLfRP0voEcrGV1MkkcfSk/view?usp=drive_link) 
+- [발표 자료](https://drive.google.com/file/d/1fo-UJqPfWZOej-NFUyJ94vb35mT6V4Q5/view?usp=drive_link)
 - [시연 영상](https://www.youtube.com/watch?v=Np8dwwVDayQ)
 
 ---------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
-#  FinalProject - SnapPop
-팀 챌린저스 최종 프로젝트
+<br>
+<br>
+
+<div align="center">
+  <img src="https://github.com/user-attachments/assets/a5b1b7d0-8361-475b-aca0-80d72e4d68ca" alt="snappop_icon" width="300px"/>
+  <h3>SnapPop</h3>
+</div>
+
+<br>
+<br>
 
 ## 🔍 프로젝트 소개 
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
 
 ## 📁 자료
 
-- [발표 자료](https://drive.google.com/file/d/1fo-UJqPfWZOej-NFUyJ94vb35mT6V4Q5/view?usp=drive_link)
+- [발표 자료](https://drive.google.com/file/d/1OXqtvrFUgWo2A0oq3FJJ1bM00xuyUC9u/view?usp=sharing)
 - [시연 영상](https://www.youtube.com/watch?v=Np8dwwVDayQ)
 
 ---------

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@
 
 ## 🎬 시연
 
-[![Watch the video](https://img.youtube.com/vi/0u_8kLCgKnY/mqdefault.jpg)](https://www.youtube.com/watch?v=0u_8kLCgKnY)
+[![Watch the video](https://img.youtube.com/vi/Np8dwwVDayQ/mqdefault.jpg)](https://www.youtube.com/watch?v=Np8dwwVDayQ)
 
 ---------
 ##### © 2024 Challengers. This project was developed by the Challengers team for the APP-iOS5th final project.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 <br>
-<br>
 
 <div align="center">
   <img src="https://github.com/user-attachments/assets/a5b1b7d0-8361-475b-aca0-80d72e4d68ca" alt="snappop_icon" width="300px"/>
   <h3>SnapPop</h3>
 </div>
 
-<br>
 <br>
 
 ## 🔍 프로젝트 소개 

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -81,20 +81,7 @@ class AddManagementViewModel {
         
         $startDate
             .sink { [weak self] newValue in
-                guard let self = self else { return }
-                
-                let startDate = self.management.startDate // 수정전 날짜 담아둘 변수
-                self.management.startDate = newValue
-                
-                if self.edit {
-                    let calendar = Calendar.current
-                    let startDateComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
-                    let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
-                    
-                    if startDateComponents != newDateComponents {
-                        self.updateCompletions()
-                    }
-                }
+                self?.management.startDate = newValue
             }
             .store(in: &cancellables)
         
@@ -137,7 +124,7 @@ class AddManagementViewModel {
         }
     }
     
-    private func updateCompletions() {
+    func updateCompletions() {
         // 초기화
         self.management.completions.removeAll()
         // 새로운 completions 값 생성

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -23,6 +23,7 @@ class AddManagementViewModel {
     @Published var detailCostArray: [DetailCost] = [] // 추가한 상세 내역들을 담을 배열
     
     var edit = false // 편집
+    var updateStartDate: Bool = false
     private var cancellables = Set<AnyCancellable>()
     var management: Management
     private let db = ManagementService()
@@ -92,6 +93,7 @@ class AddManagementViewModel {
                     let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
                     
                     if startDateComponents != newDateComponents {
+                        self.updateStartDate = true
                         self.updateCompletions()
                     }
                 }

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -23,7 +23,6 @@ class AddManagementViewModel {
     @Published var detailCostArray: [DetailCost] = [] // 추가한 상세 내역들을 담을 배열
     
     var edit = false // 편집
-    var updateStartDate: Bool = false
     private var cancellables = Set<AnyCancellable>()
     var management: Management
     private let db = ManagementService()
@@ -93,7 +92,6 @@ class AddManagementViewModel {
                     let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
                     
                     if startDateComponents != newDateComponents {
-                        self.updateStartDate = true
                         self.updateCompletions()
                     }
                 }
@@ -217,7 +215,6 @@ class AddManagementViewModel {
         }
     }
 
-    
     // 유효성 검증 프로퍼티
     var isValid: AnyPublisher<Bool, Never> {
         return Publishers.CombineLatest3($title, $color, $startDate)

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -104,7 +104,7 @@ class AddManagementViewModel {
                 guard let self = self else { return }
                 self.management.repeatCycle = newValue
                 if self.edit {
-                    self.updateCompletions()
+                    self.updateCompletionsWhenRepeatCycleChanged()
                 }
             }
             .store(in: &cancellables)
@@ -142,6 +142,18 @@ class AddManagementViewModel {
         self.management.completions.removeAll()
         // 새로운 completions 값 생성
         self.management.completions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
+    }
+    
+    private func updateCompletionsWhenRepeatCycleChanged() {
+        var newCompletions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
+        
+        for (key, value) in self.management.completions {
+            if newCompletions.keys.contains(key) {
+                newCompletions[key] = value
+            }
+        }
+        
+        self.management.completions = newCompletions
     }
     
     func categoryDidChange(to newCategoryId: String?) {

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -82,9 +82,18 @@ class AddManagementViewModel {
         $startDate
             .sink { [weak self] newValue in
                 guard let self = self else { return }
+                
+                let startDate = self.management.startDate // 수정전 날짜 담아둘 변수
                 self.management.startDate = newValue
+                
                 if self.edit {
-                    self.updateCompletions()
+                    let calendar = Calendar.current
+                    let startDateComponents = calendar.dateComponents([.year, .month, .day], from: startDate)
+                    let newDateComponents = calendar.dateComponents([.year, .month, .day], from: newValue)
+                    
+                    if startDateComponents != newDateComponents {
+                        self.updateCompletions()
+                    }
                 }
             }
             .store(in: &cancellables)

--- a/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
+++ b/SnapPop/ViewModels/Management/AddManagementViewmodel.swift
@@ -81,7 +81,11 @@ class AddManagementViewModel {
         
         $startDate
             .sink { [weak self] newValue in
-                self?.management.startDate = newValue
+                guard let self = self else { return }
+                self.management.startDate = newValue
+                if self.edit {
+                    self.updateCompletions()
+                }
             }
             .store(in: &cancellables)
         
@@ -91,7 +95,7 @@ class AddManagementViewModel {
                 guard let self = self else { return }
                 self.management.repeatCycle = newValue
                 if self.edit {
-                    self.updateCompletionsWhenRepeatCycleChanged()
+                    self.updateCompletions()
                 }
             }
             .store(in: &cancellables)
@@ -124,23 +128,11 @@ class AddManagementViewModel {
         }
     }
     
-    func updateCompletions() {
+    private func updateCompletions() {
         // 초기화
         self.management.completions.removeAll()
         // 새로운 completions 값 생성
         self.management.completions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
-    }
-    
-    private func updateCompletionsWhenRepeatCycleChanged() {
-        var newCompletions = generateSixMonthsCompletions(startDate: self.management.startDate, repeatInterval: self.management.repeatCycle)
-        
-        for (key, value) in self.management.completions {
-            if newCompletions.keys.contains(key) {
-                newCompletions[key] = value
-            }
-        }
-        
-        self.management.completions = newCompletions
     }
     
     func categoryDidChange(to newCategoryId: String?) {
@@ -202,6 +194,7 @@ class AddManagementViewModel {
         }
     }
 
+    
     // 유효성 검증 프로퍼티
     var isValid: AnyPublisher<Bool, Never> {
         return Publishers.CombineLatest3($title, $color, $startDate)

--- a/SnapPop/Views/Home/ChecklistTableViewController.swift
+++ b/SnapPop/Views/Home/ChecklistTableViewController.swift
@@ -8,31 +8,14 @@
 import UIKit
 import Combine
 
-class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class ChecklistTableViewController: UITableViewController {
     
     var viewModel: HomeViewModel?
     private var cancellables = Set<AnyCancellable>() // Combine 구독을 저장할 Set
     private let managementService = ManagementService() // ManagementService 인스턴스 추가
     
-    private lazy var tableView: UITableView = {
-        let tableView = UITableView()
-        let buttonHeight: CGFloat = 50 // 버튼의 높이
-        let bottomPadding: CGFloat = 20 // 추가 여백
-        
-        tableView.delegate = self
-        tableView.dataSource = self
-        tableView.register(ChecklistTableViewCell.self, forCellReuseIdentifier: "ChecklistCell")
-        tableView.layer.cornerRadius = 20
-        tableView.layer.masksToBounds = true
-        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: buttonHeight + bottomPadding, right: 0)
-        tableView.scrollIndicatorInsets = tableView.contentInset
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        
-        return tableView
-    }()
-    
     // 관리 항목 추가 버튼
-    private lazy var selfcareAddButton: UIButton = {
+    private let selfcareAddButton: UIButton = {
         let button = UIButton(type: .system)
         button.setTitle("새로운 관리 등록하기 +", for: .normal)
         button.setTitleColor(.white, for: .normal)
@@ -45,10 +28,19 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .dynamicBackgroundInsideColor
-        view.addSubview(tableView)
         view.addSubview(selfcareAddButton)
-        setupConstraints()
+        setupButtonConstraints()
+        view.backgroundColor = .dynamicBackgroundInsideColor
+        tableView.layer.cornerRadius = 20
+        tableView.layer.masksToBounds = true
+        
+        tableView.register(ChecklistTableViewCell.self, forCellReuseIdentifier: "ChecklistCell")
+        tableView.dataSource = self
+        tableView.delegate = self
+        let buttonHeight: CGFloat = 50 // 버튼의 높이
+        let bottomPadding: CGFloat = 20 // 추가 여백
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: buttonHeight + bottomPadding, right: 0)
+        tableView.scrollIndicatorInsets = tableView.contentInset
         
         // Combine을 사용하여 checklistItems가 변경될 때마다 테이블 뷰 업데이트
         viewModel?.$filteredItems
@@ -62,13 +54,8 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
         loadData()
     }
     
-    private func setupConstraints() {
+    private func setupButtonConstraints() {
         NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: selfcareAddButton.topAnchor, constant: -10),
-            
             selfcareAddButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             selfcareAddButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -10),
             selfcareAddButton.heightAnchor.constraint(equalToConstant: 50),
@@ -121,16 +108,16 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
     }
     
     // MARK: - UITableViewDataSource
-    func numberOfSections(in tableView: UITableView) -> Int {
+    override func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
     
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // filteredItems를 기준으로 테이블 뷰 셀 수 결정
         return viewModel?.filteredItems.isEmpty ?? true ? 1 : viewModel?.filteredItems.count ?? 0
     }
     
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let viewModel = viewModel else { return UITableViewCell() }
         // 모든 관리 항목이 없거나 현재 날짜에 관리 항목이 없는 경우
         if viewModel.checklistItems.isEmpty || viewModel.filteredItems.isEmpty {
@@ -183,7 +170,7 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
     }
     
     // 높이 설정
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         // 관리 항목이 없거나, 현재 선택된 날짜에 관리 항목이 없는 경우
         if viewModel?.checklistItems.isEmpty ?? true || viewModel?.filteredItems.isEmpty ?? true {
             return tableView.frame.height - tableView.contentInset.top - tableView.contentInset.bottom - selfcareAddButton.frame.height - 20
@@ -227,7 +214,7 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
     
     // MARK: - UITableViewDelegate
     
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let viewModel = viewModel, !viewModel.filteredItems.isEmpty, indexPath.row < viewModel.filteredItems.count else {
             return
         }
@@ -259,7 +246,7 @@ class ChecklistTableViewController: UIViewController, UITableViewDelegate, UITab
         self.navigationController?.pushViewController(addManagementVC, animated: true)
     }
 
-    func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+    override func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let viewModel = viewModel, !viewModel.filteredItems.isEmpty, indexPath.row < viewModel.filteredItems.count else {
             return nil
         }

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -89,7 +89,7 @@ class HomeViewController: UIViewController, UINavigationControllerDelegate, UITa
     }()
     // 이미지 추가 버튼
     private let addButton: UIButton = {
-        let button = UIButton(type: .system)
+        let button = UIButton(type: .custom)
         button.setTitle("+", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = UIColor.customButtonColor
@@ -321,6 +321,8 @@ class HomeViewController: UIViewController, UINavigationControllerDelegate, UITa
             checklistTableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -view.bounds.width * 0.035),
             checklistTableViewController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
+        
+        checklistTableViewController.tableView.register(ChecklistTableViewCell.self, forCellReuseIdentifier: "ChecklistCell")
     }
     /// 체크리스트( UITableViewDataSource - Number of Rows)
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/SnapPop/Views/Home/HomeViewController.swift
+++ b/SnapPop/Views/Home/HomeViewController.swift
@@ -89,7 +89,7 @@ class HomeViewController: UIViewController, UINavigationControllerDelegate, UITa
     }()
     // 이미지 추가 버튼
     private let addButton: UIButton = {
-        let button = UIButton(type: .custom)
+        let button = UIButton(type: .system)
         button.setTitle("+", for: .normal)
         button.setTitleColor(.white, for: .normal)
         button.backgroundColor = UIColor.customButtonColor
@@ -321,8 +321,6 @@ class HomeViewController: UIViewController, UINavigationControllerDelegate, UITa
             checklistTableViewController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -view.bounds.width * 0.035),
             checklistTableViewController.view.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
         ])
-        
-        checklistTableViewController.tableView.register(ChecklistTableViewCell.self, forCellReuseIdentifier: "ChecklistCell")
     }
     /// 체크리스트( UITableViewDataSource - Number of Rows)
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -52,7 +52,10 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
         setupUI()
         bindViewModel()
         setupTapGesture()
-        viewModel.startDate = self.selectedDate
+        
+        if !viewModel.edit {
+            viewModel.startDate = self.selectedDate // 수정시에 management.startDate를 selectedDate가 업데이트해버려서 처음 등록시에만 실행되게 변경
+        }
         // 알림 다시 꺼도 앱 안터지게
         isTimePickerVisible = viewModel.alertStatus
 

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -442,6 +442,7 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                         let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
                         
                         let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                            self.viewModel.updateCompletions()
                             self.presentedViewController?.dismiss(animated: false, completion: nil)
                         }
                         let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -151,6 +151,24 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
     
     // MARK: - Actions    
     @objc private func saveButtonTapped() {
+        if viewModel.updateStartDate {
+            let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
+            
+            let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                self.saveManagement()
+            }
+            let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+            
+            alert.addAction(changeAction)
+            alert.addAction(cancelAction)
+            
+            present(alert, animated: true, completion: nil)
+        } else {
+            saveManagement()
+        }
+    }
+    
+    private func saveManagement() {
         viewModel.saveOrUpdate { [weak self] result in
             switch result {
             case .success:
@@ -165,7 +183,6 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
             }
         }
     }
-
     
     @objc private func titleChanged(_ sender: UITextField) {
         // 타이틀 텍스트 필드 값 변경 시 ViewModel에 반영

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -151,24 +151,6 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
     
     // MARK: - Actions    
     @objc private func saveButtonTapped() {
-        if viewModel.updateStartDate {
-            let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
-            
-            let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
-                self.saveManagement()
-            }
-            let cancelAction = UIAlertAction(title: "취소", style: .cancel, handler: nil)
-            
-            alert.addAction(changeAction)
-            alert.addAction(cancelAction)
-            
-            present(alert, animated: true, completion: nil)
-        } else {
-            saveManagement()
-        }
-    }
-    
-    private func saveManagement() {
         viewModel.saveOrUpdate { [weak self] result in
             switch result {
             case .success:
@@ -448,13 +430,31 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "DateCell", for: indexPath) as? DateCell else {
                     return UITableViewCell()
                 }
+                
                 cell.configure(with: viewModel.startDate)
                 cell.dateChangedHandler = { [weak self] newDate in
-                    self?.viewModel.startDate = newDate
+                    guard let self = self else { return }
+                    
+                    let previousDate = self.viewModel.startDate
+                    self.viewModel.startDate = newDate
+                    
+                    if self.viewModel.edit {
+                        let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
+                        
+                        let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
+                            self.presentedViewController?.dismiss(animated: false, completion: nil)
+                        }
+                        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
+                            self.viewModel.startDate = previousDate // 취소시 변경전 날짜로 되돌림
+                            self.presentedViewController?.dismiss(animated: false, completion: nil)
+                        }
+                        
+                        alert.addAction(changeAction)
+                        alert.addAction(cancelAction)
+                        
+                        self.presentedViewController?.present(alert, animated: true, completion: nil)
+                    }
                     print("ViewModel startDate updated to: \(newDate)")
-                }
-                cell.dismissHandler = { [weak self] in
-                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
                 }
                 return cell
             case 1:

--- a/SnapPop/Views/Management/AddManagementViewController.swift
+++ b/SnapPop/Views/Management/AddManagementViewController.swift
@@ -52,10 +52,7 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
         setupUI()
         bindViewModel()
         setupTapGesture()
-        
-        if !viewModel.edit {
-            viewModel.startDate = self.selectedDate // 수정시에 management.startDate를 selectedDate가 업데이트해버려서 처음 등록시에만 실행되게 변경
-        }
+        viewModel.startDate = self.selectedDate
         // 알림 다시 꺼도 앱 안터지게
         isTimePickerVisible = viewModel.alertStatus
 
@@ -165,6 +162,7 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
             }
         }
     }
+
     
     @objc private func titleChanged(_ sender: UITextField) {
         // 타이틀 텍스트 필드 값 변경 시 ViewModel에 반영
@@ -430,32 +428,13 @@ class AddManagementViewController: UIViewController, UITableViewDelegate, UITabl
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: "DateCell", for: indexPath) as? DateCell else {
                     return UITableViewCell()
                 }
-                
                 cell.configure(with: viewModel.startDate)
                 cell.dateChangedHandler = { [weak self] newDate in
-                    guard let self = self else { return }
-                    
-                    let previousDate = self.viewModel.startDate
-                    self.viewModel.startDate = newDate
-                    
-                    if self.viewModel.edit {
-                        let alert = UIAlertController(title: "변경사항 안내", message: "날짜 변경시 완료내역이 초기화됩니다.\n 그래도 변경하시겠습니까?", preferredStyle: .alert)
-                        
-                        let changeAction = UIAlertAction(title: "변경", style: .default) { _ in
-                            self.viewModel.updateCompletions()
-                            self.presentedViewController?.dismiss(animated: false, completion: nil)
-                        }
-                        let cancelAction = UIAlertAction(title: "취소", style: .cancel) { _ in
-                            self.viewModel.startDate = previousDate // 취소시 변경전 날짜로 되돌림
-                            self.presentedViewController?.dismiss(animated: false, completion: nil)
-                        }
-                        
-                        alert.addAction(changeAction)
-                        alert.addAction(cancelAction)
-                        
-                        self.presentedViewController?.present(alert, animated: true, completion: nil)
-                    }
+                    self?.viewModel.startDate = newDate
                     print("ViewModel startDate updated to: \(newDate)")
+                }
+                cell.dismissHandler = { [weak self] in
+                    self?.presentedViewController?.dismiss(animated: false, completion: nil)
                 }
                 return cell
             case 1:


### PR DESCRIPTION
### ✨ 작업 내역

> 스냅 비교뷰 날짜별 필터링 로직 수정

- [x] SnapComparisonViewModel의 filterSnaps() 메소드 수정

### 📸 스크린샷

### 🛠️ 작업 유형

- [ ] 신규 기능 추가
- [ ] 버그 수정
- [X] 리펙토링
- [ ] 문서 업데이트

### ✅ 체크리스트

- [x] Merge 하는 브랜치가 올바른가요?
- [x] 코딩 컨벤션을 준수했나요?
- [x] PR과 관련없는 변경사항은 없나요?
- [x] 내 코드에 대한 자기 검토를 했나요?
- [ ] 변경 사항이 효과적이거나 올바르게 동작함을 보증하는 테스트를 추가했나요?
- [ ] 새로운 테스트와 기존 테스트가 변경 사항에 대해 모두 통과했나요?

### 💬 PR 특이 사항

> 1월 1일 ~ 30일의 스냅이 있다고 가정
날짜 선택 버튼 (기준 스냅)이 설정이 되지 않았다면 가장 최근의 스냅 사진이 기준이됨.
기준 스냅과 가장 근접한 과거의 스냅 사진과 비교 

ex)일주일 
```
abs(calendar.dateComponents([.day], from: createdAt, to: standardDate).day ?? 0) >= 7
```
7일보다 크거나 같다면 일주일 이상 간격으로 생각
이후 가장 근접한 과거의 스냅이 기준스냅으로 하여 또다시 다음 과거의 스냅과 비교 ...반복

> 기준스냅 즉 보고싶은 스냅을 설정하면 보이지 않던 현상 해결
Date객체는 UTC를 기준으로 저장됨, 한국은 UTC+9

// 이전 코드
```
// 선택된 날짜의 스냅이 포함되지 않았으면 맨 앞에 추가
if !filteredSnapData.contains(where: { Calendar.current.isDate($0.createdAt ?? Date(), inSameDayAs: selectedDate) }) {
    if let selectedSnap = snapData.first(where: { Calendar.current.isDate($0.createdAt ?? Date(), inSameDayAs: selectedDate) }) {
        filteredSnapData.insert(selectedSnap, at: 0)
    }
}
```

기준 스냅이 보이도록 inSameDayAs를 사용하여 추가하였었지만, UTC 차이로인한것인지 추가가 안되었었습니다..
따라서 TimeZone을 사용하여 한국시간대로 변경후 createdAt을 비교 (사실 다시 로그찍어도 UTC+9가 설정되지 않음 왜지..?)
TimeZone을 설정한 후 보고싶은 스냅 즉 기준스냅과 원본스냅의 createdAt이 같은 데이터를 찾음

// 이후 코드
```
// firebase에서 가져온 시간대는 UTC+9 가 적용이 안됨 따라서 밑의 로직을 추가하여 한국 시간대로 설정
filteredSnapData = snapData.map { snap in
    var koreanSnap = snap
    if let utcDate = snap.createdAt {
        let calendar = Calendar.current
        var components = calendar.dateComponents([.year, .month, .day], from: utcDate)
        components.timeZone = TimeZone(identifier: "Asia/Seoul")!
        components.hour = 0
        components.minute = 0
        components.second = 0
        if let koreanDate = calendar.date(from: components) {
            koreanSnap.createdAt = koreanDate
        }
    }
    return koreanSnap
}

if let selectedDate = selectedDate {
    // 선택한 날짜를 기준으로 과거 스냅 필터링
    filteredSnapData = filteredSnapData.filter { snap in
        guard let snapDate = snap.createdAt else { return false }
        return snapDate <= selectedDate
    }
}
```

- TimeZone에 대해 더 알아봐야겠습니다,,
- git merge main 하니깐 README에 충돌이 있네요 왠진모름.. (인호님과 같이 작업한 너낌 ㅋ)
# [refactor: 스냅 비교뷰 필터링 로직 수정](https://github.com/APP-iOS5th/FinalProject-SnapPop/commit/0eed9ea3df564ddc188b7a0d59ca8ae6032d040f) 이 커밋만 확인해주시면 됩니다

-  기준 스냅이 표시되지 않는 현상을 TimeZone을 사용하여 해결
- Calendar.current.dateComponents를 사용하여 두개의 스냅의 기간 비교
<br/><br/>